### PR TITLE
Fix connectivity tests for demo services

### DIFF
--- a/data/README.md
+++ b/data/README.md
@@ -2,7 +2,7 @@
 
 This folder holds minimal working examples of UnitySVC services under
 `unitysvc-demo/`, one per delivery pattern. HTTP examples relay to
-`https://echo.staing.svcmarket.com`; S3 uses `s3.staging.svcpass.com`;
+`https://echo.staging.svcmarket.com`; S3 uses `s3.staging.svcpass.com`;
 SMTP uses `mail.staging.svcmarket.com`. Use them as copy-paste starting
 points for your own services.
 
@@ -156,7 +156,7 @@ cycle. Because the admin approves the _template_ at publish time, changing
 values it references is safe.
 
 - **listing.json** declares the initial values under
-  `service_options.routing_vars` (`backend_host: "https://echo.staing.svcmarket.com"`).
+  `service_options.routing_vars` (`backend_host: "https://echo.staging.svcmarket.com"`).
 - **offering.json** references them as `{{ routing_vars.backend_host }}` in
   `upstream_access_config."Echo Service".base_url`. Rendered at request time
   only (not at enrollment).
@@ -202,10 +202,13 @@ are resolved from `customer_secrets`.
 ### `s3-byoe-params` — BYOE S3 with parameterized secret names
 
 S3 equivalent of `byoe-params`. Enrollment parameters declare which of the
-customer's secrets hold each piece of upstream config, using the
-`${ customer_secrets[enrollment_params.NAME] }` bracket lookup.
+customer's secrets hold each piece of upstream config, using the Jinja-
+rendered dot form
+`${ customer_secrets.{{ params.NAME }} }` — the inner `{{ params.NAME }}`
+resolves to the secret's name, which the secret resolver then looks up.
 
-- **offering.json** uses bracket lookup for all five upstream fields.
+- **offering.json** uses this pattern for all five upstream fields
+  (matches the same pattern as `smtp-byoe-params`).
 - **listing.json** declares a `user_parameters_schema` with the five
   parameter names (all required) and pins them to `SVCPASS_S3_*` in
   `service_options.ops_testing_parameters` for automated tests.

--- a/data/unitysvc-demo/docs/AUTHORING_GUIDE.md
+++ b/data/unitysvc-demo/docs/AUTHORING_GUIDE.md
@@ -1,0 +1,427 @@
+# Authoring Code Examples for Services
+
+A practical checklist for writing `*.j2` code examples that (a) pass
+`usvc_seller data run-tests` against the real upstream, and (b) render
+into accurate customer-facing documentation when the listing is published.
+
+This guide distills the design in
+`unitysvc-bridge-uptime/docs/fix-local-testing-params.md` into
+actionable rules. Read this first; reach for the design doc only if
+the invariant below doesn't answer your question.
+
+## The one invariant
+
+> A code example must work correctly in **both** rendering modes:
+>
+> - `local_testing=True` — rendered by `usvc_seller data run-tests`
+>   against the seller's upstream. Tests the service's raw upstream
+>   contract.
+>
+> - `local_testing=False` — rendered for customers reading the
+>   listing. Tests the gateway-routed contract.
+>
+> The two modes differ in *where inputs come from* (environment vars
+> injected by the test harness vs. gateway-provided routing). If your
+> template writes the same literals in both modes, something is wrong.
+
+If you only remember one thing from this guide: **never hardcode a
+request parameter, URL, or credential that the gateway is supposed to
+inject at runtime.** Wrap it in `{% if local_testing %}` so the test
+harness provides it in test mode and the customer-facing rendering
+shows what the customer will actually write.
+
+## File layout
+
+All examples live under `data/<provider>/docs/`, never inlined in JSON.
+
+```
+data/unitysvc-demo/
+├── docs/
+│   ├── <service-or-family>/
+│   │   ├── code-example.py.j2      # primary example customers see
+│   │   ├── connectivity.sh.j2      # minimal smoke test
+│   │   └── description.md          # optional: extra prose
+│   └── <another-family>/
+│       └── ...
+└── services/<service>/
+    ├── offering.json
+    └── listing.json                # references docs via file_path
+```
+
+Filename conventions:
+
+- `*.j2` — Jinja2-rendered template. Extension before `.j2` picks the
+  code language (`.py.j2`, `.sh.j2`, `.ts.j2`, `.json.j2`).
+- `connectivity.sh.j2` — convention for the minimal "does the pipe
+  open" smoke test. Most services should have one.
+- `code-example.*.j2` — convention for the primary example customers
+  copy-paste.
+- `description.md` — non-executable prose, shown on the listing page.
+
+Put templates in a subdirectory named after the service family (not
+the individual service); they're often shared across `byok`, `byoe`,
+and base variants of the same service (see
+`services/byoe/listing.json` and `services/byoe-params/listing.json`
+both referencing `../../docs/connectivity.sh.j2`).
+
+## Wiring a template into a listing
+
+In the service's `listing.json`, add an entry to `documents`:
+
+```json
+{
+  "documents": {
+    "Connectivity test": {
+      "category": "connectivity_test",
+      "description": "Verify endpoint is reachable",
+      "file_path": "../../docs/connectivity.sh.j2",
+      "is_active": true,
+      "is_public": false,
+      "meta": { "output_contains": "connectivity ok" },
+      "mime_type": "bash"
+    },
+    "Python example": {
+      "category": "code_examples",
+      "description": "Minimal boto3 client",
+      "file_path": "../../docs/s3/code-example.py.j2",
+      "is_active": true,
+      "is_public": true,
+      "meta": { "output_contains": "connectivity ok" },
+      "mime_type": "python"
+    }
+  }
+}
+```
+
+Key fields:
+
+- `category` — `connectivity_test` for smoke tests, `code_examples`
+  for customer-facing examples, `description` for prose.
+- `is_public` — `false` keeps the example in the seller's dashboard
+  only; `true` shows it on the public listing page.
+- `meta.output_contains` — the test harness asserts the substring is
+  present in stdout. **Case-sensitive** (see issue #52).
+- `meta.expect.status_code` — for HTTP-response tests, assert a
+  specific status (e.g., `200`).
+
+## The `local_testing` pattern
+
+### When to use it
+
+Every time a value comes from one of the following, assume you need
+to branch:
+
+1. **Routing / URL**. Test mode has direct access to the upstream;
+   customers hit `SERVICE_BASE_URL` (the gateway URL).
+2. **Authentication credentials**. Test mode uses seller-provided
+   creds from `ops_testing_parameters`; customers use their
+   `UNITYSVC_API_KEY` plus any gateway-injected secrets.
+3. **Request-body parameters**. Test mode may need to write
+   hardcoded params directly into the request body to reach upstream;
+   customers get those params injected by the gateway's routing
+   layer and should not write them themselves.
+
+### Canonical shape
+
+```jinja
+{% if local_testing %}
+# Bypass the gateway — talk to upstream directly using seller creds.
+BASE_URL=${UPSTREAM_TEST_URL}
+API_KEY=${UPSTREAM_TEST_KEY}
+{% else %}
+# Customer-facing: go through the UnitySVC gateway.
+BASE_URL=${SERVICE_BASE_URL}
+API_KEY=${UNITYSVC_API_KEY}
+{% endif %}
+```
+
+The `{% else %}` branch is **what your customer sees**. If that
+branch is wrong or incomplete, no test will catch it — the bug
+surfaces only in production. Read the `else` branch as carefully as
+the code inside it.
+
+### Real examples in this repo
+
+- `docs/connectivity.sh.j2` — HTTP connectivity test. No
+  `{% if local_testing %}` branch needed: `$SERVICE_BASE_URL` and
+  `$UNITYSVC_API_KEY` work in both modes.
+- `docs/s3/connectivity.sh.j2` — S3 connectivity test. Branches on
+  env var presence (`$S3_ENDPOINT`+`$BUCKET` vs. `$SERVICE_BASE_URL`)
+  rather than `local_testing`, since local tests construct the URL
+  from individual fields while online mode gets the fully-qualified
+  gateway URL.
+- `docs/smtp/connectivity.sh.j2` — SMTP connectivity test. Same
+  env-var-presence branching (`$HOST`+`$PORT` vs. parsing
+  `$SERVICE_BASE_URL`).
+- `docs/s3/code-example.py.j2` — full Python code example. Uses
+  `{% if local_testing %}` because the request shape genuinely
+  differs: test uses `$ACCESS_KEY`/`$SECRET_KEY` with `$S3_ENDPOINT`,
+  while the customer-facing branch uses `$UNITYSVC_API_KEY` as the S3
+  access key and parses the bucket from `$SERVICE_BASE_URL`.
+
+Steal liberally from these when writing new ones.
+
+## Context available inside a template
+
+There are two separate mechanisms, and which one to use depends on
+whether you need the value at **render time** (Jinja) or at
+**runtime** (the shell/python process the harness spawns).
+
+### Render-time: Jinja context
+
+Every `.j2` file is processed by Jinja2 with these variables in scope
+(see `unitysvc-sellers/src/unitysvc_sellers/utils.py:render_template_file`):
+
+| Variable | What it holds | Common access patterns |
+|---|---|---|
+| `local_testing` | Boolean. `True` under `run-tests`, `False` on upload and customer-facing render. | `{% if local_testing %}` |
+| `listing` | Full listing dict. | `listing.service_options.ops_testing_parameters.api_key_secret` |
+| `offering` | Full offering dict. | `offering.service_type`, `offering.upstream_access_config` |
+| `provider` | Provider metadata. | `provider.name`, `provider.display_name` |
+| `seller` | Seller metadata. | `seller.name`, `seller.contact_email` |
+| `interface` | The first upstream access interface dict. | `interface.get("access_key")`, `interface.base_url` |
+
+Use Jinja context for values that need to be **baked into the rendered
+output** (e.g., literal URLs embedded in a customer-facing example,
+or conditional text that shouldn't appear at all in one branch).
+
+### Runtime: environment variables
+
+At test time the harness (`execute_script_content` in
+`unitysvc-sellers/src/unitysvc_sellers/utils.py`) invokes the rendered
+script as a subprocess with an environment derived from the selected
+upstream access interface. The derivation rules (see
+`example.py:514-527`) are:
+
+| `upstream_access_config` field | Env var set for the test |
+|---|---|
+| `base_url` | `$SERVICE_BASE_URL` |
+| `api_key` | `$UNITYSVC_API_KEY` |
+| `routing_key` (dict) | Flattened — each sub-key uppercased (`{"model": "foo"}` → `$MODEL=foo`) |
+| everything else | Field name uppercased (`s3_endpoint` → `$S3_ENDPOINT`, `bucket` → `$BUCKET`, `host` → `$HOST`, `port` → `$PORT`, `access_key` → `$ACCESS_KEY`, …) |
+
+In **online mode** (`services run-tests`) the harness sets the same
+`$SERVICE_BASE_URL` and `$UNITYSVC_API_KEY` — but pointing at the
+gateway URL and the customer's platform API key. So **env var names
+are identical between local and online mode**; only the values
+differ. Often this means you don't need `{% if local_testing %}` at
+all — just read the env vars.
+
+Standard Jinja2 machinery is also available: `{% if %}`, `{% for %}`,
+`{{ x | default("fallback") }}`, `{{ x | tojson }}`. No custom
+filters beyond `tojson`.
+
+Favor `interface.get("field_name")` over `interface.field_name` for
+optional fields — some interfaces don't define them and direct
+attribute access raises.
+
+### When to use Jinja vs env vars
+
+- **Connectivity tests**: env vars are almost always enough — the
+  same script works for both modes without any `{% if %}`. See
+  `docs/connectivity.sh.j2`, `docs/s3/connectivity.sh.j2`, and
+  `docs/smtp/connectivity.sh.j2` in this repo.
+- **Code examples**: use `{% if local_testing %}` to branch on
+  *request shape* — e.g., the test harness might send params directly
+  in the body, while the customer-facing version relies on the
+  gateway injecting them. Don't hardcode values the gateway should
+  inject.
+- **Literal URLs or path prefixes** that differ per-render
+  (e.g., `description.md` showing the right base URL for the current
+  seller's listing): Jinja context.
+
+## The `meta` block: test assertions
+
+The harness ships a couple of simple checks. Pick the narrowest one
+that catches real failure:
+
+```json
+"meta": { "output_contains": "connectivity ok" }
+```
+Substring match against stdout. Case-sensitive (issue #52); pick a
+literal phrase you print on success.
+
+```json
+"meta": { "expect": { "status_code": 200 } }
+```
+For HTTP-response tests; assert the response status code.
+
+```json
+"meta": { "output_contains": "models", "expect": { "status_code": 200 } }
+```
+Both can be combined.
+
+**Anti-pattern:** asserting on the entire stdout, or on a dynamic
+value (timestamp, UUID, throughput number). Write a success-marker
+literal to stdout at the end of the example and assert on that —
+that's what `echo "connectivity ok"` does in every `connectivity.sh.j2`
+in this repo.
+
+## Secret references in `upstream_access_config`
+
+Seller and customer secrets appear in `offering.json`'s
+`upstream_access_config` as `${ secrets.X }` (platform / seller-owned
+secrets) or `${ customer_secrets.X }` (customer-owned, resolved by the
+gateway at enrollment/request time).
+
+### Only two forms are valid
+
+The identifier `X` after `secrets.` / `customer_secrets.` must be one
+of:
+
+1. **A literal secret name** — letters, digits, and underscores only:
+   ```json
+   "api_key": "${ customer_secrets.ECHO_API_KEY }"
+   ```
+2. **A Jinja substitution** referencing `params.KEY`, where `KEY`
+   exists in `service_options.ops_testing_parameters`:
+   ```json
+   "access_key": "${ customer_secrets.{{ params.s3_access_key_secret }} }"
+   ```
+
+Nothing else is supported. In particular:
+
+- **Bracket lookup** is *not* supported — `${ customer_secrets[X] }`
+  will pass through as a literal string and the test will fail with a
+  confusing stderr.
+- **Other Jinja namespaces** (`enrollment_vars.X`, `routing_vars.X`,
+  arbitrary expressions) inside the secret reference are *not*
+  supported yet — use `params` only.
+
+### How it resolves at test time
+
+Two stages, in order:
+
+1. **Jinja render**: the seller harness substitutes `{{ params.KEY }}`
+   using `service_options.ops_testing_parameters.KEY`. After this
+   step the reference must look like `${ customer_secrets.NAME }`
+   with a plain identifier.
+2. **Environment lookup**: the resolver reads `os.environ.get(NAME)`.
+   If the env var is set, the field is substituted with its value. If
+   not, `usvc_seller data run-tests` aborts the test with
+   `Error: secret NAME required by <field> is not defined as
+   environment variable`.
+
+### Author responsibilities
+
+- Every name referenced via `{{ params.KEY }}` must also be declared
+  in the listing's `user_parameters_schema.properties` (so customers
+  know what to provide) and have a test value in
+  `service_options.ops_testing_parameters.KEY` (so `data run-tests`
+  can exercise it). `usvc_seller data validate` enforces the
+  second part automatically via
+  `validate_required_parameter_defaults()`.
+- Export each required env var before running the tests. The harness
+  will tell you which ones are missing if you forget — see the
+  example output above.
+
+### Example: the `s3-byoe-params` service
+
+`offering.json`:
+```json
+"upstream_access_config": {
+  "S3 Upstream": {
+    "access_key": "${ customer_secrets.{{ params.s3_access_key_secret }} }",
+    "bucket":     "${ customer_secrets.{{ params.s3_bucket_secret }} }",
+    "region":     "${ customer_secrets.{{ params.s3_region_secret }} }",
+    "s3_endpoint":"${ customer_secrets.{{ params.s3_endpoint_secret }} }",
+    "secret_key": "${ customer_secrets.{{ params.s3_secret_key_secret }} }",
+    "storage_type": "s3"
+  }
+}
+```
+
+`listing.json`:
+```json
+"service_options": {
+  "ops_testing_parameters": {
+    "s3_access_key_secret":  "SVCMARKET_S3_ACCESS_KEY_ID",
+    "s3_bucket_secret":      "SVCPASS_S3_BUCKET",
+    "s3_region_secret":      "SVCPASS_S3_REGION",
+    "s3_endpoint_secret":    "SVCPASS_S3_ENDPOINT",
+    "s3_secret_key_secret":  "SVCMARKET_S3_SECRET_ACCESS_KEY"
+  }
+}
+```
+
+Before `usvc_seller data run-tests`:
+```bash
+export SVCMARKET_S3_ACCESS_KEY_ID=…
+export SVCPASS_S3_BUCKET=demo-bucket
+export SVCPASS_S3_REGION=us-east-1
+export SVCPASS_S3_ENDPOINT=https://s3.staging.svcpass.com
+export SVCMARKET_S3_SECRET_ACCESS_KEY=…
+```
+
+## Authoring checklist
+
+For each new example, before committing:
+
+- [ ] Template file lives under `data/<provider>/docs/<family>/` with
+      a `*.j2` extension.
+- [ ] Referenced from the relevant `listing.json` `documents` entry
+      with a relative `file_path`.
+- [ ] Any URL, credential, or request parameter that the gateway
+      injects at runtime is wrapped in `{% if local_testing %}`.
+- [ ] The `{% else %}` branch (what customers see) is complete and
+      correct in isolation — mentally read it without the
+      `local_testing` scaffold and confirm it works.
+- [ ] Every `${ secrets.X }` / `${ customer_secrets.X }` reference
+      uses either a literal name or `{{ params.KEY }}` — nothing
+      else (no bracket lookup, no `enrollment_vars`/`routing_vars`).
+- [ ] Every `{{ params.KEY }}` used in a secret reference has a
+      matching entry in `service_options.ops_testing_parameters`.
+- [ ] `usvc_seller data validate` passes.
+- [ ] A success marker (`connectivity ok` or similar) is echoed to
+      stdout on the happy path, and `meta.output_contains` asserts on
+      that exact literal.
+- [ ] `usvc_seller data run-tests` passes locally with the required
+      env vars exported.
+- [ ] You also rendered the non-`local_testing` output (e.g., by
+      running `usvc_seller data upload --dryrun` or equivalent) and
+      eyeballed it — does it match what you would want a customer to
+      copy-paste?
+
+That last step is the one that catches issues #47 and #48. Automated
+tests exercise the `local_testing=True` branch; the `False` branch is
+only verified by human review.
+
+## Common pitfalls
+
+**Hardcoded request-body parameters leaking into customer view.**
+Classic failure mode (issue #48). Test passes because the hardcoded
+param makes it to upstream; customer documentation shows a param they
+should *not* be writing. Fix: wrap the injection in
+`{% if local_testing %}` and ensure the `else` branch relies on
+gateway-injected values.
+
+**Tests that pass even when upstream is wrong.** If your example
+bypasses the gateway entirely (direct-to-upstream under `local_testing`)
+AND also uses the same direct URL in the `else` branch, you're never
+actually exercising the gateway path. The test is a false positive.
+Fix: the `else` branch must use `SERVICE_BASE_URL` or the appropriate
+gateway-routed URL.
+
+**`output_contains` never matching due to case.** Issue #52. Match
+the exact case you emit.
+
+**Direct access to optional interface fields.** `interface.access_key`
+raises when the field isn't set; `interface.get("access_key")` returns
+`None`. Always use `.get()` for optional fields inside `{% if %}`
+guards.
+
+**Not committing the `.j2` extension.** A file named `code-example.py`
+will be rendered as-is (no templating). Use `code-example.py.j2` so
+the Jinja pipeline runs.
+
+## References
+
+- Design rationale: `unitysvc-bridge-uptime/docs/fix-local-testing-params.md`
+- Seller-facing authoring docs: `unitysvc-sellers/docs/code-examples.md`
+- Render implementation: `unitysvc-sellers/src/unitysvc_sellers/utils.py`
+  (`render_template_file`)
+- Template-system overview: `unitysvc/docs/dev-notes/features/jinja2-template-system.md`
+- Related open issues (in `unitysvc/unitysvc-services`):
+  - #47 — JS code example tests give false positives
+  - #48 — Jinja2 secrets template not resolved in local tests
+  - #57 — Failed tests showing success

--- a/data/unitysvc-demo/docs/connectivity.sh.j2
+++ b/data/unitysvc-demo/docs/connectivity.sh.j2
@@ -1,11 +1,42 @@
 #!/bin/bash
-# Test echo relay connectivity
-{% if local_testing %}
-BASE_URL=https://echo.staing.svcmarket.com
-{% else %}
-BASE_URL=${SERVICE_BASE_URL}
-{% endif %}
-http_code=$(curl -s --max-time 5 -o /dev/null -w "%{http_code}" "${BASE_URL}")
-if [[ "$http_code" =~ ^[0-9]+$ ]] && [ "$http_code" -ge 100 ]; then
-    echo "connectivity ok"
+# Connectivity test for HTTP-based services (echo relay, mock LLM, proxy
+# variants). Verifies the endpoint is reachable AND serves a sensible
+# response. 404 / 5xx / DNS / timeout all count as failure.
+#
+# The harness sets the same env var names in both modes:
+#   $SERVICE_BASE_URL  — upstream URL (local) or gateway URL (online)
+#   $UNITYSVC_API_KEY  — upstream api_key if defined in upstream_access_config
+#                        (local), or the customer's gateway key (online)
+# Because the variable names are identical we don't branch on
+# local_testing for this test — the script works in both modes.
+set -o pipefail
+
+URL="${SERVICE_BASE_URL:?SERVICE_BASE_URL is not set}"
+
+# Split the curl invocation rather than expanding an empty array under
+# `set -u` (bash 3.2 on macOS raises on "${arr[@]}" when arr is empty).
+if [ -n "${UNITYSVC_API_KEY:-}" ]; then
+    status=$(curl -sS --max-time 5 \
+        -H "Authorization: Bearer ${UNITYSVC_API_KEY}" \
+        -o /dev/null -w "%{http_code}" "$URL" 2>/dev/null)
+else
+    status=$(curl -sS --max-time 5 \
+        -o /dev/null -w "%{http_code}" "$URL" 2>/dev/null)
 fi
+
+# Accept 2xx/3xx (alive) and 401/403 (alive, auth challenge).
+# Reject 000 (connect/DNS failure), 404 (wrong path), 5xx (broken).
+case "$status" in
+  2??|3??|401|403)
+    echo "connectivity ok (HTTP $status)"
+    exit 0
+    ;;
+  000)
+    echo "connectivity failed: could not connect to $URL" >&2
+    exit 1
+    ;;
+  *)
+    echo "connectivity failed: HTTP $status from $URL" >&2
+    exit 1
+    ;;
+esac

--- a/data/unitysvc-demo/docs/s3/connectivity.sh.j2
+++ b/data/unitysvc-demo/docs/s3/connectivity.sh.j2
@@ -1,20 +1,35 @@
 #!/bin/bash
-{% if local_testing %}
-{% if interface.get("s3_endpoint") %}
-# Local testing: verify S3-compatible endpoint is reachable
-curl -s -o /dev/null -w "%{http_code}" \
-    "{{ interface.s3_endpoint }}" \
-    | grep -q "200\|301\|403" && echo "connectivity ok"
-{% else %}
-# Local testing: verify S3 bucket endpoint is reachable
-curl -s -o /dev/null -w "%{http_code}" \
-    "https://{{ interface.bucket }}.s3.{{ interface.region }}.amazonaws.com/" \
-    | grep -q "200\|301\|307\|403" && echo "connectivity ok"
-{% endif %}
-{% else %}
-# Verify S3 gateway endpoint is reachable (any HTTP response means gateway is up)
-STATUS=$(curl -s -o /dev/null -w "%{http_code}" "$SERVICE_BASE_URL/")
-echo "Gateway responded with status $STATUS"
-# Any response (even 401/403) means the gateway is reachable
-[ "$STATUS" -gt 0 ] 2>/dev/null && echo "connectivity ok"
-{% endif %}
+# Connectivity test for S3-compatible content services. An unsigned GET
+# on the bucket returns 2xx/3xx (public) or 401/403 (signed access
+# required) — either confirms the endpoint is alive. Anything else
+# (000 / 404 / 5xx) is treated as failure.
+#
+# Env var layout the harness provides:
+#   local mode   — $S3_ENDPOINT, $BUCKET  (from upstream_access_config)
+#   online mode  — $SERVICE_BASE_URL      (fully-qualified gateway bucket path)
+# We branch on whichever is present so the same script works in both.
+set -o pipefail
+
+if [ -n "${S3_ENDPOINT:-}" ] && [ -n "${BUCKET:-}" ]; then
+    URL="${S3_ENDPOINT%/}/${BUCKET}/"
+else
+    URL="${SERVICE_BASE_URL:?need S3_ENDPOINT+BUCKET or SERVICE_BASE_URL}"
+    URL="${URL%/}/"
+fi
+
+status=$(curl -sS --max-time 5 -o /dev/null -w "%{http_code}" "$URL" 2>/dev/null)
+
+case "$status" in
+  2??|3??|401|403)
+    echo "connectivity ok (HTTP $status)"
+    exit 0
+    ;;
+  000)
+    echo "connectivity failed: could not connect to $URL" >&2
+    exit 1
+    ;;
+  *)
+    echo "connectivity failed: HTTP $status from $URL" >&2
+    exit 1
+    ;;
+esac

--- a/data/unitysvc-demo/docs/smtp/connectivity.sh.j2
+++ b/data/unitysvc-demo/docs/smtp/connectivity.sh.j2
@@ -1,14 +1,34 @@
 #!/bin/bash
-# Test SMTP connectivity
-{% if local_testing %}
-# Local testing: HOST and PORT from upstream_access_config
-SMTP_HOST=${HOST:-localhost}
-SMTP_PORT=${PORT:-587}
-{% else %}
-# Gateway testing: parse SERVICE_BASE_URL (smtp://host:port)
-SMTP_HOST=$(echo "$SERVICE_BASE_URL" | sed -E 's|^smtps?://||' | cut -d: -f1)
-SMTP_PORT=$(echo "$SERVICE_BASE_URL" | sed -E 's|^smtps?://||' | cut -d: -f2 | cut -d/ -f1)
-SMTP_HOST=${SMTP_HOST:-localhost}
-SMTP_PORT=${SMTP_PORT:-587}
-{% endif %}
-(sleep 1; echo "QUIT") | nc -w5 "$SMTP_HOST" "$SMTP_PORT" | grep -q "220" && echo "connectivity ok"
+# Connectivity test for SMTP services. A healthy mail server sends a
+# "220 ... ESMTP ..." greeting on connect; anything else (no response,
+# timeout, or other greeting code) is treated as failure.
+#
+# Env var layout the harness provides:
+#   local mode   — $HOST, $PORT  (from upstream_access_config)
+#   online mode  — $SERVICE_BASE_URL  (smtp://host:port or smtps://host:port)
+# We branch on whichever is present so the same script works in both.
+set -o pipefail
+
+if [ -n "${HOST:-}" ]; then
+    PORT="${PORT:-587}"
+else
+    URL="${SERVICE_BASE_URL:?need HOST or SERVICE_BASE_URL}"
+    stripped="${URL#smtp://}"
+    stripped="${stripped#smtps://}"
+    HOST="${stripped%%:*}"
+    PORT="${stripped#*:}"
+    PORT="${PORT%%/*}"
+    PORT="${PORT:-587}"
+fi
+
+# `nc -w 5` caps both connect wait and idle-after-banner wait. Send QUIT
+# so the server closes cleanly instead of timing out on us.
+greeting=$( (echo "QUIT"; sleep 1) | nc -w 5 "$HOST" "$PORT" 2>/dev/null | head -1 )
+
+if [[ "$greeting" == "220 "* ]]; then
+    echo "connectivity ok ($greeting)"
+    exit 0
+fi
+
+echo "connectivity failed: expected '220 ...' greeting from ${HOST}:${PORT}, got: ${greeting:-<no response>}" >&2
+exit 1

--- a/data/unitysvc-demo/services/byok/offering.json
+++ b/data/unitysvc-demo/services/byok/offering.json
@@ -16,7 +16,7 @@
     "Echo Service": {
       "access_method": "http",
       "api_key": "${ customer_secrets.ECHO_API_KEY }",
-      "base_url": "https://echo.staing.svcmarket.com"
+      "base_url": "https://echo.staging.svcmarket.com"
     }
   }
 }

--- a/data/unitysvc-demo/services/enrollment_vars/offering.json
+++ b/data/unitysvc-demo/services/enrollment_vars/offering.json
@@ -14,7 +14,7 @@
   "upstream_access_config": {
     "Echo Service": {
       "access_method": "http",
-      "base_url": "https://echo.staing.svcmarket.com/{{ enrollment_vars.code }}"
+      "base_url": "https://echo.staging.svcmarket.com/{{ enrollment_vars.code }}"
     }
   }
 }

--- a/data/unitysvc-demo/services/params/offering.json
+++ b/data/unitysvc-demo/services/params/offering.json
@@ -14,7 +14,7 @@
   "upstream_access_config": {
     "Echo Service": {
       "access_method": "http",
-      "base_url": "https://echo.staing.svcmarket.com",
+      "base_url": "https://echo.staging.svcmarket.com",
       "routing_key": {
         "model": "{{ params.model }}"
       }

--- a/data/unitysvc-demo/services/recurrent/offering.json
+++ b/data/unitysvc-demo/services/recurrent/offering.json
@@ -14,7 +14,7 @@
   "upstream_access_config": {
     "Echo Service": {
       "access_method": "http",
-      "base_url": "https://echo.staing.svcmarket.com"
+      "base_url": "https://echo.staging.svcmarket.com"
     }
   }
 }

--- a/data/unitysvc-demo/services/relay/offering.json
+++ b/data/unitysvc-demo/services/relay/offering.json
@@ -10,7 +10,7 @@
   "upstream_access_config": {
     "Echo Service": {
       "access_method": "http",
-      "base_url": "https://echo.staing.svcmarket.com"
+      "base_url": "https://echo.staging.svcmarket.com"
     }
   }
 }

--- a/data/unitysvc-demo/services/routing_vars/listing.json
+++ b/data/unitysvc-demo/services/routing_vars/listing.json
@@ -22,7 +22,7 @@
   "schema": "listing_v1",
   "service_options": {
     "routing_vars": {
-      "backend_host": "https://echo.staing.svcmarket.com"
+      "backend_host": "https://echo.staging.svcmarket.com"
     }
   },
   "status": "ready",

--- a/data/unitysvc-demo/services/s3-byoe-params/offering.json
+++ b/data/unitysvc-demo/services/s3-byoe-params/offering.json
@@ -20,12 +20,12 @@
   "time_created": "2026-04-18T00:00:00Z",
   "upstream_access_config": {
     "S3 Upstream": {
-      "access_key": "${ customer_secrets[enrollment_params.s3_access_key_secret] }",
+      "access_key": "${ customer_secrets.{{ params.s3_access_key_secret }} }",
       "access_method": "http",
-      "bucket": "${ customer_secrets[enrollment_params.s3_bucket_secret] }",
-      "region": "${ customer_secrets[enrollment_params.s3_region_secret] }",
-      "s3_endpoint": "${ customer_secrets[enrollment_params.s3_endpoint_secret] }",
-      "secret_key": "${ customer_secrets[enrollment_params.s3_secret_key_secret] }",
+      "bucket": "${ customer_secrets.{{ params.s3_bucket_secret }} }",
+      "region": "${ customer_secrets.{{ params.s3_region_secret }} }",
+      "s3_endpoint": "${ customer_secrets.{{ params.s3_endpoint_secret }} }",
+      "secret_key": "${ customer_secrets.{{ params.s3_secret_key_secret }} }",
       "storage_type": "s3"
     }
   }


### PR DESCRIPTION
## Summary

Three bug classes caused most connectivity tests in the demo services to fail on \`usvc_seller data run-tests\`:

### 1. DNS typo \`staing\` → \`staging\` (7 files)

\`echo.staing.svcmarket.com\` does not resolve (\`NXDOMAIN\`). Fixed across \`connectivity.sh.j2\`, \`README.md\`, and the \`relay\`, \`byok\`, \`params\`, \`recurrent\`, \`enrollment_vars\`, \`routing_vars\` offerings/listings.

### 2. Templates hardcoded the URL instead of reading the harness env vars

The test harness already maps \`upstream_access_config\` fields into the test subprocess environment (see \`unitysvc-sellers/src/unitysvc_sellers/example.py:514-527\`):

- \`base_url\` → \`\$SERVICE_BASE_URL\`
- \`api_key\` → \`\$UNITYSVC_API_KEY\`
- everything else uppercased (\`s3_endpoint\` → \`\$S3_ENDPOINT\`, \`bucket\` → \`\$BUCKET\`, \`host\` → \`\$HOST\`, \`port\` → \`\$PORT\`, …)

The names are **identical** between local (\`data run-tests\`) and online (\`services run-tests\`) modes — only the values differ. So the same connectivity script works in both without any \`local_testing\` branching.

All three connectivity templates rewritten to read from env vars with explicit \`:?\` guards:

- \`docs/connectivity.sh.j2\` (HTTP): \`\$SERVICE_BASE_URL\`, optional \`\$UNITYSVC_API_KEY\`
- \`docs/s3/connectivity.sh.j2\`: branches on \`\$S3_ENDPOINT\`+\`\$BUCKET\` presence vs. \`\$SERVICE_BASE_URL\`
- \`docs/smtp/connectivity.sh.j2\`: branches on \`\$HOST\` presence vs. parsed \`\$SERVICE_BASE_URL\`

Acceptance semantics per the revised spec:
- **HTTP/S3**: 2xx/3xx/401/403 = ok; 000 / 404 / 5xx = fail. (401 on S3 is "bucket up, signing required" — counted as reachable.)
- **SMTP**: a \`220 ... ESMTP ...\` banner within 5s.

### 3. \`s3-byoe-params/offering.json\` used unsupported bracket syntax

The field values used \`\${ customer_secrets[enrollment_params.X] }\` — bracket lookup with a non-existent Jinja variable. Neither the seller harness secret resolver (regex matches dot notation only) nor the gateway supports this form.

Rewritten to match the \`smtp-byoe-params\` convention of dot notation with a Jinja-rendered secret name:

\`\`\`json
\"access_key\": \"\${ customer_secrets.{{ params.s3_access_key_secret }} }\"
\`\`\`

At test time Jinja substitutes \`{{ params.s3_access_key_secret }}\` from \`service_options.ops_testing_parameters\` (harness maps \`ops_testing_parameters\` → \`params\` in Jinja context); the resolver then matches the resulting \`\${ customer_secrets.NAME }\` dot form and reads the env var.

## New authoring guide

Added [\`data/unitysvc-demo/docs/AUTHORING_GUIDE.md\`](data/unitysvc-demo/docs/AUTHORING_GUIDE.md) — a practical guide for adding new services. Covers:

- File layout, naming conventions, when to reuse a template across service variants.
- The \`{% if local_testing %}\` pattern: when it's necessary (code examples that differ by request shape) and when it isn't (connectivity tests that read the same env vars in both modes).
- The canonical secret reference forms: \`\${ secrets.NAME }\` / \`\${ customer_secrets.NAME }\` / \`\${ customer_secrets.{{ params.KEY }} }\`. Bracket syntax is **not** supported.
- The two-stage secret resolution pipeline (Jinja render → env-var lookup) and what env vars the author must export before \`data run-tests\`.
- A checklist covering the two new rules so authors don't ship the same bug classes this PR fixed.

## Verification

Each rewritten template smoke-tested against the real upstreams before committing:

\`\`\`
HTTP (echo, no auth)        → ok (HTTP 200)
HTTP (echo, with auth)      → ok (HTTP 200)
HTTP (mock LLM upstream)    → ok (HTTP 200)
S3  (local: endpoint+bucket) → ok (HTTP 401)
SMTP (local: host+port)     → ok (220 ESMTP Haraka…)
NEG bogus host              → failed: could not connect
NEG 404                     → failed: HTTP 404
NEG missing SERVICE_BASE_URL → failed: SERVICE_BASE_URL is not set
\`\`\`

## Test plan

- [ ] \`usvc_seller data validate\` passes on all demo services.
- [ ] \`usvc_seller data run-tests\` shows \`✓ Pass\` for \`relay\`, \`routing_vars\`, \`byok\`, \`params\`, \`enrollment_vars\`, \`recurrent\`, \`llm\`, and base \`s3\` connectivity tests.
- [ ] \`s3-byoe-params\` connectivity test runs (or cleanly skips if its env vars aren't set) rather than failing with a literal-string URL in stderr.
- [ ] The rewritten \`s3-byoe-params\` upstream fields render correctly when the test env vars (\`SVCMARKET_S3_ACCESS_KEY_ID\`, \`SVCPASS_S3_BUCKET\`, \`SVCPASS_S3_ENDPOINT\`, \`SVCPASS_S3_REGION\`, \`SVCMARKET_S3_SECRET_ACCESS_KEY\`) are exported.