### PR TITLE
Switch smtp services to mailpit and smtp_connectivity_v2

### DIFF
--- a/data/README.md
+++ b/data/README.md
@@ -2,8 +2,8 @@
 
 This folder holds minimal working examples of UnitySVC services under
 `unitysvc-demo/`, one per delivery pattern. HTTP examples relay to
-`https://echo.staging.svcmarket.com`; S3 uses `s3.staging.svcpass.com`;
-SMTP uses `mail.staging.svcmarket.com`. Use them as copy-paste starting
+`https://echo.svcmarket.com`; S3 uses `s3.staging.svcpass.com`;
+SMTP uses `mail.svcmarket.com`. Use them as copy-paste starting
 points for your own services.
 
 ## Service overview
@@ -47,7 +47,7 @@ that make a service an LLM on the marketplace.
   a `details` block with `context_window`, `max_input_tokens`,
   `max_output_tokens`, `mode: "chat"`, and a token-based `payout_price`
   (`type: "one_million_tokens"`) with split `input` / `output` rates.
-  Upstream is `https://mock.staging.svcmarket.com/openai/v1` (OpenAI-compatible).
+  Upstream is `https://mock.svcmarket.com/openai/v1` (OpenAI-compatible).
 - **listing.json** uses token-based `list_price` (input/output split), gateway
   path `${API_GATEWAY_BASE_URL}/demo/llm`, and a `request_template` document
   (`docs/llm/request-template.json`) that pre-fills the marketplace playground
@@ -156,7 +156,7 @@ cycle. Because the admin approves the _template_ at publish time, changing
 values it references is safe.
 
 - **listing.json** declares the initial values under
-  `service_options.routing_vars` (`backend_host: "https://echo.staging.svcmarket.com"`).
+  `service_options.routing_vars` (`backend_host: "https://echo.svcmarket.com"`).
 - **offering.json** references them as `{{ routing_vars.backend_host }}` in
   `upstream_access_config."Echo Service".base_url`. Rendered at request time
   only (not at enrollment).
@@ -220,7 +220,7 @@ HTTP or S3 gateway). Seller-managed upstream; no customer enrollment or
 secrets required.
 
 - **offering.json** `upstream_access_config` uses `access_method: "smtp"` plus
-  SMTP-specific fields: `host: "mail.staging.svcmarket.com"`, `port: 587`,
+  SMTP-specific fields: `host: "mail.svcmarket.com"`, `port: 587`,
   `tls: true`.
 - **listing.json** `user_access_interfaces."SMTP Gateway"` uses
   `access_method: "smtp"`, `base_url: "${SMTP_GATEWAY_BASE_URL}"`, and a
@@ -266,16 +266,16 @@ variables: …" message) if any referenced variable is unset.
 Export the variables below before running the tests. Services not
 listed here require no environment configuration.
 
-| Service            | Required env vars                                            | Optional                       |
-| ------------------ | ------------------------------------------------------------ | ------------------------------ |
-| `byok`             | —                                                            | `ECHO_API_KEY` (→ empty)       |
-| `byoe`             | `ECHO_BYOE_BASE_URL`, `ECHO_BYOE_API_KEY`                    |                                |
-| `byoe-params`      | `ECHO_BYOE_BASE_URL`, `ECHO_BYOE_API_KEY`                    |                                |
-| `s3`               | `S3_ACCESS_KEY`, `S3_SECRET_KEY`                             |                                |
-| `s3-byoe`          | `S3_ENDPOINT`, `S3_BUCKET`, `S3_ACCESS_KEY`, `S3_SECRET_KEY` | `S3_REGION` (→ `us-east-1`)    |
-| `s3-byoe-params`   | `S3_ENDPOINT`, `S3_BUCKET`, `S3_ACCESS_KEY`, `S3_SECRET_KEY` | `S3_REGION` (→ `us-east-1`)    |
-| `smtp-byoe`        | `SMTP_HOST`, `SMTP_PORT`, `SMTP_USERNAME`, `SMTP_PASSWORD`   |                                |
-| `smtp-byoe-params` | `SMTP_HOST`, `SMTP_PORT`, `SMTP_USERNAME`, `SMTP_PASSWORD`   |                                |
+| Service            | Required env vars                                            | Optional                    |
+| ------------------ | ------------------------------------------------------------ | --------------------------- |
+| `byok`             | —                                                            | `ECHO_API_KEY` (→ empty)    |
+| `byoe`             | `ECHO_BYOE_BASE_URL`, `ECHO_BYOE_API_KEY`                    |                             |
+| `byoe-params`      | `ECHO_BYOE_BASE_URL`, `ECHO_BYOE_API_KEY`                    |                             |
+| `s3`               | `S3_ACCESS_KEY`, `S3_SECRET_KEY`                             |                             |
+| `s3-byoe`          | `S3_ENDPOINT`, `S3_BUCKET`, `S3_ACCESS_KEY`, `S3_SECRET_KEY` | `S3_REGION` (→ `us-east-1`) |
+| `s3-byoe-params`   | `S3_ENDPOINT`, `S3_BUCKET`, `S3_ACCESS_KEY`, `S3_SECRET_KEY` | `S3_REGION` (→ `us-east-1`) |
+| `smtp-byoe`        | `SMTP_HOST`, `SMTP_PORT`, `SMTP_USERNAME`, `SMTP_PASSWORD`   |                             |
+| `smtp-byoe-params` | `SMTP_HOST`, `SMTP_PORT`, `SMTP_USERNAME`, `SMTP_PASSWORD`   |                             |
 
 Notes:
 

--- a/data/unitysvc-demo/services/byoe-params/listing.json
+++ b/data/unitysvc-demo/services/byoe-params/listing.json
@@ -7,7 +7,7 @@
     }
   },
   "list_price": {
-    "description": "Free — customer provides own endpoint and API key",
+    "description": "Free \u2014 customer provides own endpoint and API key",
     "price": "0",
     "type": "constant"
   },

--- a/data/unitysvc-demo/services/byoe/listing.json
+++ b/data/unitysvc-demo/services/byoe/listing.json
@@ -7,7 +7,7 @@
     }
   },
   "list_price": {
-    "description": "Free — customer provides own endpoint and API key",
+    "description": "Free \u2014 customer provides own endpoint and API key",
     "price": "0",
     "type": "constant"
   },

--- a/data/unitysvc-demo/services/byok/listing.json
+++ b/data/unitysvc-demo/services/byok/listing.json
@@ -7,7 +7,7 @@
     }
   },
   "list_price": {
-    "description": "Free — customer brings own API key",
+    "description": "Free \u2014 customer brings own API key",
     "price": "0",
     "type": "constant"
   },

--- a/data/unitysvc-demo/services/byok/offering.json
+++ b/data/unitysvc-demo/services/byok/offering.json
@@ -16,7 +16,7 @@
     "Echo Service": {
       "access_method": "http",
       "api_key": "${ customer_secrets.ECHO_API_KEY ?? }",
-      "base_url": "https://echo.staging.svcmarket.com"
+      "base_url": "https://echo.svcmarket.com"
     }
   }
 }

--- a/data/unitysvc-demo/services/enrollment_vars/offering.json
+++ b/data/unitysvc-demo/services/enrollment_vars/offering.json
@@ -14,7 +14,7 @@
   "upstream_access_config": {
     "Echo Service": {
       "access_method": "http",
-      "base_url": "https://echo.staging.svcmarket.com/{{ enrollment_vars.code }}"
+      "base_url": "https://echo.svcmarket.com/{{ enrollment_vars.code }}"
     }
   }
 }

--- a/data/unitysvc-demo/services/llm/offering.json
+++ b/data/unitysvc-demo/services/llm/offering.json
@@ -3,7 +3,7 @@
     "llm"
   ],
   "currency": "USD",
-  "description": "Mock LLM service for integration testing. Relays OpenAI-compatible chat completion requests through the UnitySVC API gateway to the mock upstream at `mock.staging.svcmarket.com/openai/v1` \u2014 lets you develop against a real gateway path without incurring provider costs.",
+  "description": "Mock LLM service for integration testing. Relays OpenAI-compatible chat completion requests through the UnitySVC API gateway to the mock upstream at `mock.svcmarket.com/openai/v1` \u2014 lets you develop against a real gateway path without incurring provider costs.",
   "details": {
     "context_window": 8192,
     "max_input_tokens": 8192,
@@ -30,7 +30,7 @@
   "upstream_access_config": {
     "Mock LLM API": {
       "access_method": "http",
-      "base_url": "https://mock.staging.svcmarket.com/openai/v1"
+      "base_url": "https://mock.svcmarket.com/openai/v1"
     }
   }
 }

--- a/data/unitysvc-demo/services/params/offering.json
+++ b/data/unitysvc-demo/services/params/offering.json
@@ -14,7 +14,7 @@
   "upstream_access_config": {
     "Echo Service": {
       "access_method": "http",
-      "base_url": "https://echo.staging.svcmarket.com",
+      "base_url": "https://echo.svcmarket.com",
       "routing_key": {
         "model": "{{ params.model }}"
       }

--- a/data/unitysvc-demo/services/recurrent/offering.json
+++ b/data/unitysvc-demo/services/recurrent/offering.json
@@ -14,7 +14,7 @@
   "upstream_access_config": {
     "Echo Service": {
       "access_method": "http",
-      "base_url": "https://echo.staging.svcmarket.com"
+      "base_url": "https://echo.svcmarket.com"
     }
   }
 }

--- a/data/unitysvc-demo/services/relay/offering.json
+++ b/data/unitysvc-demo/services/relay/offering.json
@@ -14,7 +14,7 @@
   "upstream_access_config": {
     "Echo Service": {
       "access_method": "http",
-      "base_url": "https://echo.staging.svcmarket.com"
+      "base_url": "https://echo.svcmarket.com"
     }
   }
 }

--- a/data/unitysvc-demo/services/routing_vars/listing.json
+++ b/data/unitysvc-demo/services/routing_vars/listing.json
@@ -14,7 +14,7 @@
   "schema": "listing_v1",
   "service_options": {
     "routing_vars": {
-      "backend_host": "https://echo.staging.svcmarket.com"
+      "backend_host": "https://echo.svcmarket.com"
     }
   },
   "status": "ready",

--- a/data/unitysvc-demo/services/s3-byoe-params/listing.json
+++ b/data/unitysvc-demo/services/s3-byoe-params/listing.json
@@ -13,7 +13,7 @@
     }
   },
   "list_price": {
-    "description": "Free — customer provides own bucket and credentials",
+    "description": "Free \u2014 customer provides own bucket and credentials",
     "price": "0",
     "type": "constant"
   },

--- a/data/unitysvc-demo/services/s3-byoe/listing.json
+++ b/data/unitysvc-demo/services/s3-byoe/listing.json
@@ -13,7 +13,7 @@
     }
   },
   "list_price": {
-    "description": "Free — customer provides own bucket and credentials",
+    "description": "Free \u2014 customer provides own bucket and credentials",
     "price": "0",
     "type": "constant"
   },

--- a/data/unitysvc-demo/services/s3/offering.json
+++ b/data/unitysvc-demo/services/s3/offering.json
@@ -24,7 +24,7 @@
       "base_path": "demo/",
       "bucket": "demo",
       "region": "us-east-1",
-      "s3_endpoint": "https://s3.staging.svcmarket.com",
+      "s3_endpoint": "https://s3.svcmarket.com",
       "secret_key": "${ secrets.S3_SECRET_KEY }",
       "storage_type": "s3"
     }

--- a/data/unitysvc-demo/services/smtp-byoe-params/listing.json
+++ b/data/unitysvc-demo/services/smtp-byoe-params/listing.json
@@ -7,7 +7,7 @@
     }
   },
   "list_price": {
-    "description": "Free — customer provides own SMTP server",
+    "description": "Free \u2014 customer provides own SMTP server",
     "price": "0",
     "type": "constant"
   },

--- a/data/unitysvc-demo/services/smtp-byoe-params/listing.json
+++ b/data/unitysvc-demo/services/smtp-byoe-params/listing.json
@@ -3,7 +3,7 @@
   "display_name": "SMTP Relay (BYOE, parameterized secrets)",
   "documents": {
     "Connectivity test": {
-      "$doc_preset": "smtp_connectivity"
+      "$doc_preset": "smtp_connectivity_v2"
     }
   },
   "list_price": {

--- a/data/unitysvc-demo/services/smtp-byoe-params/offering.json
+++ b/data/unitysvc-demo/services/smtp-byoe-params/offering.json
@@ -24,7 +24,7 @@
       "host": "${ customer_secrets.{{ params.SMTP_HOST_SECRET }} }",
       "password": "${ customer_secrets.{{ params.SMTP_PASSWORD_SECRET }} }",
       "port": "${ customer_secrets.{{ params.SMTP_PORT_SECRET }} }",
-      "tls": true,
+      "tls": false,
       "username": "${ customer_secrets.{{ params.SMTP_USERNAME_SECRET }} }"
     }
   }

--- a/data/unitysvc-demo/services/smtp-byoe/listing.json
+++ b/data/unitysvc-demo/services/smtp-byoe/listing.json
@@ -7,7 +7,7 @@
     }
   },
   "list_price": {
-    "description": "Free — customer provides own SMTP server",
+    "description": "Free \u2014 customer provides own SMTP server",
     "price": "0",
     "type": "constant"
   },

--- a/data/unitysvc-demo/services/smtp-byoe/listing.json
+++ b/data/unitysvc-demo/services/smtp-byoe/listing.json
@@ -3,7 +3,7 @@
   "display_name": "SMTP Relay (Bring Your Own Endpoint)",
   "documents": {
     "Connectivity test": {
-      "$doc_preset": "smtp_connectivity"
+      "$doc_preset": "smtp_connectivity_v2"
     }
   },
   "list_price": {

--- a/data/unitysvc-demo/services/smtp-byoe/offering.json
+++ b/data/unitysvc-demo/services/smtp-byoe/offering.json
@@ -24,7 +24,7 @@
       "host": "${ customer_secrets.SMTP_HOST }",
       "password": "${ customer_secrets.SMTP_PASSWORD }",
       "port": "${ customer_secrets.SMTP_PORT }",
-      "tls": true,
+      "tls": false,
       "username": "${ customer_secrets.SMTP_USERNAME }"
     }
   }

--- a/data/unitysvc-demo/services/smtp/listing.json
+++ b/data/unitysvc-demo/services/smtp/listing.json
@@ -3,7 +3,7 @@
   "display_name": "SMTP Relay (Demo)",
   "documents": {
     "Connectivity test": {
-      "$doc_preset": "smtp_connectivity"
+      "$doc_preset": "smtp_connectivity_v2"
     }
   },
   "list_price": {

--- a/data/unitysvc-demo/services/smtp/listing.override.json
+++ b/data/unitysvc-demo/services/smtp/listing.override.json
@@ -1,4 +1,4 @@
 {
   "name": "smtp",
-  "service_id": "2aaeb5dc-2e92-47ec-b560-ab25b1801635"
+  "service_id": "20ac9363-05a3-4e52-ada2-04c8b0d56f16"
 }

--- a/data/unitysvc-demo/services/smtp/offering.json
+++ b/data/unitysvc-demo/services/smtp/offering.json
@@ -1,8 +1,6 @@
 {
-  "capabilities": [
-    "smtp_relay"
-  ],
-  "description": "Simple SMTP relay. Routes messages through the UnitySVC SMTP gateway to the upstream mail server at `mail.svcmarket.com`. Seller-managed upstream; no customer enrollment or secrets required.",
+  "capabilities": ["smtp_relay"],
+  "description": "Simple SMTP relay. Routes messages through the UnitySVC SMTP gateway to the upstream mail server at `mailpit.svcmarket.com`. Seller-managed upstream; no customer enrollment or secrets required.",
   "name": "smtp",
   "payout_price": {
     "description": "Free demo relay",
@@ -12,18 +10,14 @@
   "schema": "offering_v1",
   "service_type": "email",
   "status": "ready",
-  "tags": [
-    "email",
-    "smtp",
-    "gateway"
-  ],
+  "tags": ["email", "smtp", "gateway"],
   "time_created": "2026-04-18T00:00:00Z",
   "upstream_access_config": {
     "Mail Relay": {
       "access_method": "smtp",
-      "host": "mail.svcmarket.com",
-      "port": 587,
-      "tls": true
+      "host": "mailpit.svcmarket.com",
+      "port": 1025,
+      "tls": false
     }
   }
 }

--- a/data/unitysvc-demo/services/smtp/offering.json
+++ b/data/unitysvc-demo/services/smtp/offering.json
@@ -1,5 +1,7 @@
 {
-  "capabilities": ["smtp_relay"],
+  "capabilities": [
+    "smtp_relay"
+  ],
   "description": "Simple SMTP relay. Routes messages through the UnitySVC SMTP gateway to the upstream mail server at `mailpit.svcmarket.com`. Seller-managed upstream; no customer enrollment or secrets required.",
   "name": "smtp",
   "payout_price": {
@@ -10,7 +12,11 @@
   "schema": "offering_v1",
   "service_type": "email",
   "status": "ready",
-  "tags": ["email", "smtp", "gateway"],
+  "tags": [
+    "email",
+    "smtp",
+    "gateway"
+  ],
   "time_created": "2026-04-18T00:00:00Z",
   "upstream_access_config": {
     "Mail Relay": {

--- a/data/unitysvc-demo/services/smtp/offering.json
+++ b/data/unitysvc-demo/services/smtp/offering.json
@@ -2,7 +2,7 @@
   "capabilities": [
     "smtp_relay"
   ],
-  "description": "Simple SMTP relay. Routes messages through the UnitySVC SMTP gateway to the upstream mail server at `mail.staging.svcmarket.com`. Seller-managed upstream; no customer enrollment or secrets required.",
+  "description": "Simple SMTP relay. Routes messages through the UnitySVC SMTP gateway to the upstream mail server at `mail.svcmarket.com`. Seller-managed upstream; no customer enrollment or secrets required.",
   "name": "smtp",
   "payout_price": {
     "description": "Free demo relay",
@@ -21,7 +21,7 @@
   "upstream_access_config": {
     "Mail Relay": {
       "access_method": "smtp",
-      "host": "mail.staging.svcmarket.com",
+      "host": "mail.svcmarket.com",
       "port": 587,
       "tls": true
     }


### PR DESCRIPTION
## Summary

- **smtp**: upstream updated from `mail.svcmarket.com:587` → `mailpit.svcmarket.com:1025` (`tls: false` to match Mailpit's plain-SMTP setup)
- **smtp, smtp-byoe, smtp-byoe-params**: connectivity test pinned to `smtp_connectivity_v2`, which adds TLS/SMTPS support via `openssl s_client` (released in unitysvc-data 0.1.5)
- **smtp-byoe, smtp-byoe-params**: `tls: false` in offering to match Mailpit demo configuration

## Test plan

- [x] `usvc_seller data run-tests` — all 3 smtp connectivity tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)