### PR TITLE
data: rename non-slug interface keys to URL-friendly slugs

### DIFF
--- a/data/unitysvc-demo/services/byoe-params/listing.json
+++ b/data/unitysvc-demo/services/byoe-params/listing.json
@@ -21,7 +21,7 @@
   "status": "ready",
   "time_created": "2026-04-18T00:00:00Z",
   "user_access_interfaces": {
-    "HTTP Gateway": {
+    "http_gateway": {
       "access_method": "http",
       "base_url": "${API_GATEWAY_BASE_URL}/demo/echo-byoe-params"
     }

--- a/data/unitysvc-demo/services/byoe-params/offering.json
+++ b/data/unitysvc-demo/services/byoe-params/offering.json
@@ -13,7 +13,7 @@
   ],
   "time_created": "2026-04-18T00:00:00Z",
   "upstream_access_config": {
-    "Echo Service": {
+    "echo_service": {
       "access_method": "http",
       "api_key": "${ customer_secrets.{{ params.api_key_secret }} ?? }",
       "base_url": "${ customer_secrets.{{ params.base_url_secret }} }"

--- a/data/unitysvc-demo/services/byoe/listing.json
+++ b/data/unitysvc-demo/services/byoe/listing.json
@@ -15,7 +15,7 @@
   "status": "ready",
   "time_created": "2026-04-18T00:00:00Z",
   "user_access_interfaces": {
-    "HTTP Gateway": {
+    "http_gateway": {
       "access_method": "http",
       "base_url": "${API_GATEWAY_BASE_URL}/demo/echo-byoe"
     }

--- a/data/unitysvc-demo/services/byoe/offering.json
+++ b/data/unitysvc-demo/services/byoe/offering.json
@@ -13,7 +13,7 @@
   ],
   "time_created": "2026-04-18T00:00:00Z",
   "upstream_access_config": {
-    "Echo Service": {
+    "echo_service": {
       "access_method": "http",
       "api_key": "${ customer_secrets.ECHO_BYOE_API_KEY ?? }",
       "base_url": "${ customer_secrets.ECHO_BYOE_BASE_URL }"

--- a/data/unitysvc-demo/services/byok/listing.json
+++ b/data/unitysvc-demo/services/byok/listing.json
@@ -15,7 +15,7 @@
   "status": "ready",
   "time_created": "2026-04-18T00:00:00Z",
   "user_access_interfaces": {
-    "HTTP Gateway": {
+    "http_gateway": {
       "access_method": "http",
       "base_url": "${API_GATEWAY_BASE_URL}/demo/echo-byok"
     }

--- a/data/unitysvc-demo/services/byok/offering.json
+++ b/data/unitysvc-demo/services/byok/offering.json
@@ -13,7 +13,7 @@
   ],
   "time_created": "2026-04-18T00:00:00Z",
   "upstream_access_config": {
-    "Echo Service": {
+    "echo_service": {
       "access_method": "http",
       "api_key": "${ customer_secrets.ECHO_API_KEY ?? }",
       "base_url": "https://echo.svcmarket.com"

--- a/data/unitysvc-demo/services/enrollment_vars/listing.json
+++ b/data/unitysvc-demo/services/enrollment_vars/listing.json
@@ -20,7 +20,7 @@
   "status": "ready",
   "time_created": "2026-04-18T00:00:00Z",
   "user_access_interfaces": {
-    "HTTP Gateway": {
+    "http_gateway": {
       "access_method": "http",
       "base_url": "${API_GATEWAY_BASE_URL}/demo/echo-enrollment-vars/{{ enrollment_vars.code }}"
     }

--- a/data/unitysvc-demo/services/enrollment_vars/offering.json
+++ b/data/unitysvc-demo/services/enrollment_vars/offering.json
@@ -12,7 +12,7 @@
   ],
   "time_created": "2026-04-18T00:00:00Z",
   "upstream_access_config": {
-    "Echo Service": {
+    "echo_service": {
       "access_method": "http",
       "base_url": "https://echo.svcmarket.com/{{ enrollment_vars.code }}"
     }

--- a/data/unitysvc-demo/services/llm/listing.json
+++ b/data/unitysvc-demo/services/llm/listing.json
@@ -22,7 +22,7 @@
   "status": "ready",
   "time_created": "2026-04-18T00:00:00Z",
   "user_access_interfaces": {
-    "HTTP Gateway": {
+    "http_gateway": {
       "access_method": "http",
       "base_url": "${API_GATEWAY_BASE_URL}/demo/llm"
     }

--- a/data/unitysvc-demo/services/llm/offering.json
+++ b/data/unitysvc-demo/services/llm/offering.json
@@ -28,7 +28,7 @@
   ],
   "time_created": "2026-04-18T00:00:00Z",
   "upstream_access_config": {
-    "Mock LLM API": {
+    "mock_llm_api": {
       "access_method": "http",
       "base_url": "https://mock.svcmarket.com/openai/v1"
     }

--- a/data/unitysvc-demo/services/params/listing.json
+++ b/data/unitysvc-demo/services/params/listing.json
@@ -20,7 +20,7 @@
   "status": "ready",
   "time_created": "2026-04-18T00:00:00Z",
   "user_access_interfaces": {
-    "HTTP Gateway": {
+    "http_gateway": {
       "access_method": "http",
       "base_url": "${API_GATEWAY_BASE_URL}/demo/echo-params",
       "routing_key": {

--- a/data/unitysvc-demo/services/params/offering.json
+++ b/data/unitysvc-demo/services/params/offering.json
@@ -12,7 +12,7 @@
   ],
   "time_created": "2026-04-18T00:00:00Z",
   "upstream_access_config": {
-    "Echo Service": {
+    "echo_service": {
       "access_method": "http",
       "base_url": "https://echo.svcmarket.com",
       "routing_key": {

--- a/data/unitysvc-demo/services/recurrent/listing.json
+++ b/data/unitysvc-demo/services/recurrent/listing.json
@@ -21,7 +21,7 @@
   "status": "ready",
   "time_created": "2026-04-18T00:00:00Z",
   "user_access_interfaces": {
-    "HTTP Gateway": {
+    "http_gateway": {
       "access_method": "http",
       "base_url": "${API_GATEWAY_BASE_URL}/demo/echo-recurrent"
     }

--- a/data/unitysvc-demo/services/recurrent/offering.json
+++ b/data/unitysvc-demo/services/recurrent/offering.json
@@ -12,7 +12,7 @@
   ],
   "time_created": "2026-04-18T00:00:00Z",
   "upstream_access_config": {
-    "Echo Service": {
+    "echo_service": {
       "access_method": "http",
       "base_url": "https://echo.svcmarket.com"
     }

--- a/data/unitysvc-demo/services/relay/listing.json
+++ b/data/unitysvc-demo/services/relay/listing.json
@@ -15,7 +15,7 @@
   "status": "ready",
   "time_created": "2026-04-18T00:00:00Z",
   "user_access_interfaces": {
-    "HTTP Gateway": {
+    "http_gateway": {
       "access_method": "http",
       "base_url": "${API_GATEWAY_BASE_URL}/demo/echo-relay"
     }

--- a/data/unitysvc-demo/services/relay/offering.json
+++ b/data/unitysvc-demo/services/relay/offering.json
@@ -12,7 +12,7 @@
   ],
   "time_created": "2026-04-18T00:00:00Z",
   "upstream_access_config": {
-    "Echo Service": {
+    "echo_service": {
       "access_method": "http",
       "base_url": "https://echo.svcmarket.com"
     }

--- a/data/unitysvc-demo/services/routing_vars/listing.json
+++ b/data/unitysvc-demo/services/routing_vars/listing.json
@@ -20,7 +20,7 @@
   "status": "ready",
   "time_created": "2026-04-18T00:00:00Z",
   "user_access_interfaces": {
-    "HTTP Gateway": {
+    "http_gateway": {
       "access_method": "http",
       "base_url": "${API_GATEWAY_BASE_URL}/demo/echo-routing-vars"
     }

--- a/data/unitysvc-demo/services/routing_vars/offering.json
+++ b/data/unitysvc-demo/services/routing_vars/offering.json
@@ -12,7 +12,7 @@
   ],
   "time_created": "2026-04-18T00:00:00Z",
   "upstream_access_config": {
-    "Echo Service": {
+    "echo_service": {
       "access_method": "http",
       "base_url": "{{ routing_vars.backend_host }}"
     }

--- a/data/unitysvc-demo/services/s3-byoe-params/listing.json
+++ b/data/unitysvc-demo/services/s3-byoe-params/listing.json
@@ -30,7 +30,7 @@
   "status": "ready",
   "time_created": "2026-04-18T00:00:00Z",
   "user_access_interfaces": {
-    "S3 Gateway": {
+    "s3_gateway": {
       "access_method": "http",
       "base_url": "${S3_GATEWAY_BASE_URL}/demo-s3-byoe-params"
     }

--- a/data/unitysvc-demo/services/s3-byoe-params/offering.json
+++ b/data/unitysvc-demo/services/s3-byoe-params/offering.json
@@ -19,7 +19,7 @@
   ],
   "time_created": "2026-04-18T00:00:00Z",
   "upstream_access_config": {
-    "S3 Upstream": {
+    "s3_upstream": {
       "access_key": "${ customer_secrets.{{ params.s3_access_key_secret }} }",
       "access_method": "http",
       "bucket": "${ customer_secrets.{{ params.s3_bucket_secret }} }",

--- a/data/unitysvc-demo/services/s3-byoe/listing.json
+++ b/data/unitysvc-demo/services/s3-byoe/listing.json
@@ -21,7 +21,7 @@
   "status": "ready",
   "time_created": "2026-04-18T00:00:00Z",
   "user_access_interfaces": {
-    "S3 Gateway": {
+    "s3_gateway": {
       "access_method": "http",
       "base_url": "${S3_GATEWAY_BASE_URL}/demo-s3-byoe"
     }

--- a/data/unitysvc-demo/services/s3-byoe/offering.json
+++ b/data/unitysvc-demo/services/s3-byoe/offering.json
@@ -19,7 +19,7 @@
   ],
   "time_created": "2026-04-18T00:00:00Z",
   "upstream_access_config": {
-    "S3 Upstream": {
+    "s3_upstream": {
       "access_key": "${ customer_secrets.S3_ACCESS_KEY }",
       "access_method": "http",
       "bucket": "${ customer_secrets.S3_BUCKET }",

--- a/data/unitysvc-demo/services/s3/listing.json
+++ b/data/unitysvc-demo/services/s3/listing.json
@@ -21,7 +21,7 @@
   "status": "ready",
   "time_created": "2026-04-18T00:00:00Z",
   "user_access_interfaces": {
-    "S3 Gateway": {
+    "s3_gateway": {
       "access_method": "http",
       "base_url": "${S3_GATEWAY_BASE_URL}/demo-s3"
     }

--- a/data/unitysvc-demo/services/s3/offering.json
+++ b/data/unitysvc-demo/services/s3/offering.json
@@ -18,7 +18,7 @@
   ],
   "time_created": "2026-04-18T00:00:00Z",
   "upstream_access_config": {
-    "S3 Upstream": {
+    "s3_upstream": {
       "access_key": "${ secrets.S3_ACCESS_KEY }",
       "access_method": "http",
       "base_path": "demo/",

--- a/data/unitysvc-demo/services/smtp-byoe-params/listing.json
+++ b/data/unitysvc-demo/services/smtp-byoe-params/listing.json
@@ -23,7 +23,7 @@
   "status": "ready",
   "time_created": "2026-04-18T00:00:00Z",
   "user_access_interfaces": {
-    "SMTP Gateway": {
+    "smtp_gateway": {
       "access_method": "smtp",
       "base_url": "${SMTP_GATEWAY_BASE_URL}",
       "routing_key": {

--- a/data/unitysvc-demo/services/smtp-byoe-params/offering.json
+++ b/data/unitysvc-demo/services/smtp-byoe-params/offering.json
@@ -19,7 +19,7 @@
   ],
   "time_created": "2026-04-18T00:00:00Z",
   "upstream_access_config": {
-    "Customer SMTP": {
+    "customer_smtp": {
       "access_method": "smtp",
       "host": "${ customer_secrets.{{ params.SMTP_HOST_SECRET }} }",
       "password": "${ customer_secrets.{{ params.SMTP_PASSWORD_SECRET }} }",

--- a/data/unitysvc-demo/services/smtp-byoe/listing.json
+++ b/data/unitysvc-demo/services/smtp-byoe/listing.json
@@ -15,7 +15,7 @@
   "status": "ready",
   "time_created": "2026-04-18T00:00:00Z",
   "user_access_interfaces": {
-    "SMTP Gateway": {
+    "smtp_gateway": {
       "access_method": "smtp",
       "base_url": "${SMTP_GATEWAY_BASE_URL}",
       "routing_key": {

--- a/data/unitysvc-demo/services/smtp-byoe/offering.json
+++ b/data/unitysvc-demo/services/smtp-byoe/offering.json
@@ -19,7 +19,7 @@
   ],
   "time_created": "2026-04-18T00:00:00Z",
   "upstream_access_config": {
-    "Customer SMTP": {
+    "customer_smtp": {
       "access_method": "smtp",
       "host": "${ customer_secrets.SMTP_HOST }",
       "password": "${ customer_secrets.SMTP_PASSWORD }",

--- a/data/unitysvc-demo/services/smtp/listing.json
+++ b/data/unitysvc-demo/services/smtp/listing.json
@@ -15,7 +15,7 @@
   "status": "ready",
   "time_created": "2026-04-18T00:00:00Z",
   "user_access_interfaces": {
-    "SMTP Gateway": {
+    "smtp_gateway": {
       "access_method": "smtp",
       "base_url": "${SMTP_GATEWAY_BASE_URL}",
       "routing_key": {

--- a/data/unitysvc-demo/services/smtp/offering.json
+++ b/data/unitysvc-demo/services/smtp/offering.json
@@ -19,7 +19,7 @@
   ],
   "time_created": "2026-04-18T00:00:00Z",
   "upstream_access_config": {
-    "Mail Relay": {
+    "mail_relay": {
       "access_method": "smtp",
       "host": "mailpit.svcmarket.com",
       "port": 1025,


### PR DESCRIPTION
## Summary

Renames the keys of `upstream_access_config` (offering files) and `user_access_interfaces` (listing files) so they conform to the slug pattern (`^[a-z0-9][a-z0-9_-]*$`) the unitysvc backend now enforces on `AccessInterface.name`.

Renames in this repo:
  [9] user_access_interfaces: 'HTTP Gateway' -> 'http_gateway'
  [8] upstream_access_config: 'Echo Service' -> 'echo_service'
  [3] user_access_interfaces: 'S3 Gateway' -> 's3_gateway'
  [3] upstream_access_config: 'S3 Upstream' -> 's3_upstream'
  [3] user_access_interfaces: 'SMTP Gateway' -> 'smtp_gateway'
  [2] upstream_access_config: 'Customer SMTP' -> 'customer_smtp'
  [1] upstream_access_config: 'Mock LLM API' -> 'mock_llm_api'
  [1] upstream_access_config: 'Mail Relay' -> 'mail_relay'

Values are unchanged. This is a mechanical key rename applied via a small Python script across all seller-data repos.

## Test plan

- [x] `git diff --stat` confirms only the intended JSON files changed.
- [x] Spot-check diff: only the dictionary keys flip; surrounding entries identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)