### PR TITLE
fix: add context_length and parameter_count to demo LLM offering

### DIFF
--- a/data/unitysvc-demo/services/llm/offering.json
+++ b/data/unitysvc-demo/services/llm/offering.json
@@ -3,19 +3,19 @@
     "llm"
   ],
   "currency": "USD",
-  "description": "Mock LLM service for integration testing. Relays OpenAI-compatible chat completion requests through the UnitySVC API gateway to the mock upstream at `mock.svcmarket.com/openai/v1` — lets you develop against a real gateway path without incurring provider costs.",
+  "description": "Mock LLM service for integration testing. Relays OpenAI-compatible chat completion requests through the UnitySVC API gateway to the mock upstream at `mock.svcmarket.com/openai/v1` \u2014 lets you develop against a real gateway path without incurring provider costs.",
   "details": {
+    "context_length": 8192,
     "context_window": 8192,
     "max_input_tokens": 8192,
     "max_output_tokens": 2048,
     "mode": "chat",
-    "context_length": 8192,
     "parameter_count": null
   },
   "display_name": "Demo LLM Chat (Mock)",
   "name": "llm",
   "payout_price": {
-    "description": "Mock pricing — $0.50 / 1M input tokens, $1.50 / 1M output tokens",
+    "description": "Mock pricing \u2014 $0.50 / 1M input tokens, $1.50 / 1M output tokens",
     "input": "0.50",
     "output": "1.50",
     "type": "one_million_tokens"

--- a/data/unitysvc-demo/services/llm/offering.json
+++ b/data/unitysvc-demo/services/llm/offering.json
@@ -3,17 +3,19 @@
     "llm"
   ],
   "currency": "USD",
-  "description": "Mock LLM service for integration testing. Relays OpenAI-compatible chat completion requests through the UnitySVC API gateway to the mock upstream at `mock.svcmarket.com/openai/v1` \u2014 lets you develop against a real gateway path without incurring provider costs.",
+  "description": "Mock LLM service for integration testing. Relays OpenAI-compatible chat completion requests through the UnitySVC API gateway to the mock upstream at `mock.svcmarket.com/openai/v1` — lets you develop against a real gateway path without incurring provider costs.",
   "details": {
     "context_window": 8192,
     "max_input_tokens": 8192,
     "max_output_tokens": 2048,
-    "mode": "chat"
+    "mode": "chat",
+    "context_length": 8192,
+    "parameter_count": null
   },
   "display_name": "Demo LLM Chat (Mock)",
   "name": "llm",
   "payout_price": {
-    "description": "Mock pricing \u2014 $0.50 / 1M input tokens, $1.50 / 1M output tokens",
+    "description": "Mock pricing — $0.50 / 1M input tokens, $1.50 / 1M output tokens",
     "input": "0.50",
     "output": "1.50",
     "type": "one_million_tokens"


### PR DESCRIPTION
## Summary

- Adds `context_length=8192` and `parameter_count=null` to the demo LLM offering to satisfy the updated [unitysvc-core validation](https://github.com/unitysvc/unitysvc-core/pull/10)
- `context_length` derived from the existing `context_window` value; `parameter_count` is null (mock service)

## Test plan

- [x] `usvc_seller data validate` passes locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)