### PR TITLE
demo llm: add OpenAI SDK code example for marketplace render testing

### DIFF
--- a/data/unitysvc-demo/services/llm/listing.json
+++ b/data/unitysvc-demo/services/llm/listing.json
@@ -10,6 +10,9 @@
         "is_public": true,
         "name": "llm_request_template"
       }
+    },
+    "OpenAI SDK example (Python)": {
+      "$doc_preset": "llm_code_example_openai"
     }
   },
   "list_price": {
@@ -24,7 +27,10 @@
   "user_access_interfaces": {
     "http_gateway": {
       "access_method": "http",
-      "base_url": "${API_GATEWAY_BASE_URL}/demo/llm"
+      "base_url": "${API_GATEWAY_BASE_URL}/demo/llm",
+      "routing_key": {
+        "model": "mock-llm-chat"
+      }
     }
   }
 }

--- a/data/unitysvc-demo/services/llm/listing.override.json
+++ b/data/unitysvc-demo/services/llm/listing.override.json
@@ -1,4 +1,4 @@
 {
   "name": "llm",
-  "service_id": "f23a328a-bbe6-4ab6-a2b5-9534aa697a84"
+  "service_id": "3e28b1d5-2c0e-4aa5-bfe9-8f2cecf68f08"
 }


### PR DESCRIPTION
## Summary

Adds an OpenAI SDK code example to the `unitysvc-demo/llm` service (the demo LLM service that's served by the local stack and exercised by manual testing of the marketplace flow).

Two changes to [data/unitysvc-demo/services/llm/listing.json](data/unitysvc-demo/services/llm/listing.json):

1. New document `"OpenAI SDK example (Python)"` referencing the `llm_code_example_openai` preset from [unitysvc-data](https://github.com/unitysvc/unitysvc-data) — a Python script using the `openai` SDK with `base_url`, `model`, and env-var `UNITYSVC_API_KEY`.
2. New `routing_key.model: "mock-llm-chat"` on the `http_gateway` interface, so the rendered code-example has a real model name in the `model=` slot.

Together these cover the marketplace's new server-side render path ([unitysvc/unitysvc#892](https://github.com/unitysvc/unitysvc/pull/892)) — the customer-facing service-detail page now shows a fully-resolved Python snippet (gateway URL substituted, `mock-llm-chat` inlined for the model, API key still env-var since it's per-customer) instead of raw `{{ ... }}` placeholders.

## Test plan

- [x] `usvc_seller data validate data` passes
- [x] After upload, the marketplace `/market/<llm-service-uuid>` page shows the rendered Python code in the `Code Examples` tab.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
