### PR TITLE
listings: drop redundant is_public:true overrides on $doc_preset

### DIFF
--- a/data/unitysvc-demo/services/llm/listing.json
+++ b/data/unitysvc-demo/services/llm/listing.json
@@ -6,10 +6,7 @@
       "$doc_preset": "api_connectivity"
     },
     "Default request body": {
-      "$doc_preset": {
-        "is_public": true,
-        "name": "llm_request_template"
-      }
+      "$doc_preset": "llm_request_template"
     },
     "OpenAI SDK example (Python)": {
       "$doc_preset": "llm_code_example_openai"


### PR DESCRIPTION
## Summary

Mechanical sweep: every preset is already `is_public: true` since [unitysvc-data 0.1.9](https://github.com/unitysvc/unitysvc-data/releases/tag/v0.1.9), so an explicit `is_public: true` override on a `$doc_preset` block is just noise. Drop it; if `name` is the only field left, collapse to the bare-string form `"$doc_preset": "<preset_name>"`.

`is_public: false` overrides (genuinely making a doc private) are preserved — they still flip the default.

## Test plan

- [x] `usvc_seller data validate` passes