### PR TITLE
listings: switch LLM connectivity to llm_connectivity, drop dead skip_test

### DIFF
--- a/data/unitysvc-demo/services/llm/listing.json
+++ b/data/unitysvc-demo/services/llm/listing.json
@@ -3,7 +3,7 @@
   "display_name": "Demo LLM Chat (Mock)",
   "documents": {
     "Connectivity test": {
-      "$doc_preset": "api_connectivity"
+      "$doc_preset": "llm_connectivity"
     },
     "Default request body": {
       "$doc_preset": {

--- a/data/unitysvc-demo/services/params/listing.json
+++ b/data/unitysvc-demo/services/params/listing.json
@@ -3,7 +3,7 @@
   "display_name": "Demo HTTP Relay (Enrollment Params)",
   "documents": {
     "Connectivity test": {
-      "$doc_preset": "api_connectivity"
+      "$doc_preset": "llm_connectivity"
     }
   },
   "list_price": {


### PR DESCRIPTION
## Summary

Two mechanical sweeps over every `listing.json` that's LLM-shaped (has `routing_key.model`):

### 1. `api_connectivity` → `llm_connectivity`

`api_connectivity` is a generic GET-the-URL probe. For an LLM service it tells you nothing useful — only "the gateway is alive". The new `llm_connectivity` preset (in [unitysvc-data#23](https://github.com/unitysvc/unitysvc-data/pull/23)) POSTs a one-token chat completion against `{{ routing_key.model }}` and asserts a real `choices` array came back, so the customer / run-tests / marketplace can tell that the gateway *and* the model are both healthy.

### 2. Drop `meta.skip_test: true` overrides

`skip_test` isn't a recognized platform meta key — the run-tests flow ignores it (verified by experiment: presets with `skip_test: true` were running anyway). Code examples should run unless they need a niche dep the platform's test environment doesn't install; the recognized "skip" shape is `meta.test.status: "skip"`, which is left alone.

After the strips, if the `$doc_preset` override block has only `name` left, it collapses to the bare-string form `"$doc_preset": "<preset>"`.

## Dependency

This PR depends on [unitysvc-data#23](https://github.com/unitysvc/unitysvc-data/pull/23) (adds `llm_connectivity`) being released before the published seller CLI can resolve the new preset name.

## Test plan

- [x] `usvc_seller data validate` passes (verified locally with editable `unitysvc-data` branch).
