### PR TITLE
demo smtp listings: add Python code example via smtp_code_example preset

### DIFF
--- a/data/unitysvc-demo/services/smtp-byoe-params/listing.json
+++ b/data/unitysvc-demo/services/smtp-byoe-params/listing.json
@@ -4,10 +4,13 @@
   "documents": {
     "Connectivity test": {
       "$doc_preset": "smtp_connectivity_v2"
+    },
+    "Python code example": {
+      "$doc_preset": "smtp_code_example"
     }
   },
   "list_price": {
-    "description": "Free \u2014 customer provides own SMTP server",
+    "description": "Free — customer provides own SMTP server",
     "price": "0",
     "type": "constant"
   },

--- a/data/unitysvc-demo/services/smtp-byoe-params/listing.json
+++ b/data/unitysvc-demo/services/smtp-byoe-params/listing.json
@@ -10,7 +10,7 @@
     }
   },
   "list_price": {
-    "description": "Free — customer provides own SMTP server",
+    "description": "Free \u2014 customer provides own SMTP server",
     "price": "0",
     "type": "constant"
   },

--- a/data/unitysvc-demo/services/smtp-byoe/listing.json
+++ b/data/unitysvc-demo/services/smtp-byoe/listing.json
@@ -4,10 +4,13 @@
   "documents": {
     "Connectivity test": {
       "$doc_preset": "smtp_connectivity_v2"
+    },
+    "Python code example": {
+      "$doc_preset": "smtp_code_example"
     }
   },
   "list_price": {
-    "description": "Free \u2014 customer provides own SMTP server",
+    "description": "Free — customer provides own SMTP server",
     "price": "0",
     "type": "constant"
   },

--- a/data/unitysvc-demo/services/smtp-byoe/listing.json
+++ b/data/unitysvc-demo/services/smtp-byoe/listing.json
@@ -10,7 +10,7 @@
     }
   },
   "list_price": {
-    "description": "Free — customer provides own SMTP server",
+    "description": "Free \u2014 customer provides own SMTP server",
     "price": "0",
     "type": "constant"
   },

--- a/data/unitysvc-demo/services/smtp/listing.json
+++ b/data/unitysvc-demo/services/smtp/listing.json
@@ -4,6 +4,9 @@
   "documents": {
     "Connectivity test": {
       "$doc_preset": "smtp_connectivity_v2"
+    },
+    "Python code example": {
+      "$doc_preset": "smtp_code_example"
     }
   },
   "list_price": {


### PR DESCRIPTION
## Summary

Brings the three demo SMTP listings (`smtp`, `smtp-byoe`, `smtp-byoe-params`) in line with the canonical seller listings in [`unitysvc-services-smtp`](https://github.com/unitysvc-labs/unitysvc-services-smtp) — those already reference the `smtp_code_example` preset (shipped in [unitysvc-data v0.1.11](https://github.com/unitysvc/unitysvc-data/releases/tag/v0.1.11) via [#22](https://github.com/unitysvc/unitysvc-data/pull/22)).

Each demo service was shipping with only the `Connectivity test` document; this adds:

```json
"Python code example": { "$doc_preset": "smtp_code_example" }
```

so the demo render path has a customer-facing snippet to display alongside.

## Test plan

- [x] `usvc_seller data validate` — clean (against the published `unitysvc-data` 0.1.11)