### PR TITLE
upload-data: read secrets under their actual UNITYSVC_SELLER_* names

### DIFF
--- a/.github/workflows/upload-data.yml
+++ b/.github/workflows/upload-data.yml
@@ -28,8 +28,8 @@ jobs:
 
       - name: Upload services
         env:
-          UNITYSVC_SELLER_API_KEY: ${{ secrets.UNITYSVC_API_KEY }}
-          UNITYSVC_SELLER_API_URL: ${{ secrets.SERVICE_API_URL }}
+          UNITYSVC_SELLER_API_KEY: ${{ secrets.UNITYSVC_SELLER_API_KEY }}
+          UNITYSVC_SELLER_API_URL: ${{ secrets.UNITYSVC_SELLER_API_URL }}
         run: |
           echo "Uploading services..."
           usvc_seller data upload
@@ -48,8 +48,8 @@ jobs:
 
       - name: Submit services for review
         env:
-          UNITYSVC_SELLER_API_KEY: ${{ secrets.UNITYSVC_API_KEY }}
-          UNITYSVC_SELLER_API_URL: ${{ secrets.SERVICE_API_URL }}
+          UNITYSVC_SELLER_API_KEY: ${{ secrets.UNITYSVC_SELLER_API_KEY }}
+          UNITYSVC_SELLER_API_URL: ${{ secrets.UNITYSVC_SELLER_API_URL }}
         run: |
           echo "Submitting services for review..."
           usvc_seller services submit --from-data --data-dir data --yes


### PR DESCRIPTION
## Summary

The `upload-data.yml` workflow was reading `secrets.UNITYSVC_API_KEY` and `secrets.SERVICE_API_URL`, then renaming them into the env vars the seller CLI expects (`UNITYSVC_SELLER_API_KEY` / `UNITYSVC_SELLER_API_URL`). The org-level secrets are stored under the canonical `UNITYSVC_SELLER_*` names directly, so the old rename resolved to empty values and the upload step failed with `Missing seller API key`.

Drop the rename — read the canonical secret names directly. Verified by inspecting the failing run env block:

```
UNITYSVC_SELLER_API_KEY:
UNITYSVC_SELLER_API_URL:
```

Both empty (vs the `***` mask GitHub uses when a secret is actually resolved).

## Note

Every seller-data repo using this workflow shape (deepseek, cerebras, cohere, fireworks, mistral, nebius, …) is hitting the same failure on every merge. Same fix needs to land on each. Happy to open the sweep once this lands and confirms the secret names are right.