### PR TITLE
upload-data: rename submit flag --from-data -> --local-ids

### DIFF
--- a/.github/workflows/upload-data.yml
+++ b/.github/workflows/upload-data.yml
@@ -52,7 +52,7 @@ jobs:
           UNITYSVC_SELLER_API_URL: ${{ secrets.UNITYSVC_SELLER_API_URL }}
         run: |
           echo "Submitting services for review..."
-          usvc_seller services submit --from-data --data-dir data --yes
+          usvc_seller services submit --local-ids --data-dir data --yes
 
       - name: Upload summary
         if: always()


### PR DESCRIPTION
Follow-up to #27. The auth fix worked (secrets resolved, all 16 services ingested) but the submit step failed on:

```
No such option: --from-data
```

The seller CLI renamed this option to `--local-ids` (`-l`):

```
--local-ids  -l   Restrict to services whose IDs are recorded
                  in listing_v1 files under --data-dir.
```

One-line workflow fix.