### PR TITLE
enrollment_vars demo: use intrinsic {{ enrollment.code }} (drop enrollment_vars)

### DIFF
--- a/data/README.md
+++ b/data/README.md
@@ -16,7 +16,7 @@ points for your own services.
 | `byoe`             | HTTP    | no         | customer `base_url` + `api_key`    | BYOE pattern                                      |
 | `params`           | HTTP    | yes        | none                               | user parameter as routing key                     |
 | `byoe-params`      | HTTP    | yes        | customer, names via params         | parameterized secret names                        |
-| `enrollment_vars`  | HTTP    | yes        | none                               | `{{ enrollment.code }}` for per-enrollment URL    |
+| `enrollment`       | HTTP    | yes        | none                               | `{{ enrollment.code }}` for per-enrollment URL    |
 | `recurrent`        | HTTP    | yes        | none                               | `prompt_recurrence` scheduling                    |
 | `routing_vars`     | HTTP    | no         | none                               | post-activation seller knobs via `routing_vars`   |
 | `s3`               | S3      | no         | seller `access_key` / `secret_key` | S3-specific upstream fields                       |
@@ -112,7 +112,7 @@ customer — each enrollment points at a different pair of secrets.
   `ops_testing_parameters` pins them to `ECHO_BYOE_BASE_URL` /
   `ECHO_BYOE_API_KEY` for automated tests.
 
-### `enrollment_vars` — Per-enrollment code in URLs
+### `enrollment` — Per-enrollment code in URLs
 
 Demonstrates per-enrollment routing using the intrinsic `{{ enrollment.code }}`.
 Every enrollment has a unique 4-character `code`, so it can be embedded directly
@@ -168,7 +168,7 @@ values it references is safe.
   usvc services update routing_vars --set-routing-var backend_host=https://echo.other.example.com
   ```
 
-Contrast with `enrollment_vars` (per-enrollment, customer-initiated) and
+Contrast with `enrollment` (per-enrollment, customer-initiated) and
 `customer_secrets` (customer-owned, looked up at request time).
 The same pattern works for S3 (`{{ routing_vars.bucket }}`) or SMTP
 (`{{ routing_vars.host }}`).

--- a/data/README.md
+++ b/data/README.md
@@ -115,21 +115,27 @@ customer — each enrollment points at a different pair of secrets.
 ### `enrollment_vars` — Per-enrollment variables
 
 Demonstrates `service_options.enrollment_vars`: values rendered once per
-enrollment and reusable in any access interface template. Here a 6-char
-code is generated at enrollment time and embedded in both the user-facing
-gateway path and the upstream URL, so every enrollment gets a unique route.
+enrollment and reusable in any access interface template. Here the
+enrollment's intrinsic 4-character `code` is captured into an enrollment var
+and embedded in both the user-facing gateway path and the upstream URL, so
+every enrollment gets a unique route.
 
 - **listing.json** declares
-  `service_options.enrollment_vars.code = "{{ enrollment_code(6) }}"` and uses
+  `service_options.enrollment_vars.code = "{{ enrollment.code }}"` and uses
   `{{ enrollment_vars.code }}` inside
   `user_access_interfaces."HTTP Gateway".base_url`.
 - **offering.json** references the same `{{ enrollment_vars.code }}` inside
   `upstream_access_config."Echo Service".base_url` so the gateway forwards to
   the matching upstream path.
 
-Rendering runs in two phases: `enrollment_vars` first (so `{{ enrollment_code(6) }}`
-materialises to something like `VTXBNM`), then the access interface URL
-templates consume the rendered value.
+Rendering runs in two phases: `enrollment_vars` first (so `{{ enrollment.code }}`
+materialises to the enrollment's 4-character code, e.g. `CEFF`), then the
+access interface URL templates consume the rendered value.
+
+> Every enrollment also has a built-in `code` reachable directly at
+> `/e/<code>` regardless of `base_url` — `{{ enrollment.code }}` exposes that
+> same value. It replaces the old `enrollment_code()` template function (the
+> length argument is gone; the code is always 4 characters).
 
 ### `recurrent` — Scheduled execution
 

--- a/data/README.md
+++ b/data/README.md
@@ -16,7 +16,7 @@ points for your own services.
 | `byoe`             | HTTP    | no         | customer `base_url` + `api_key`    | BYOE pattern                                      |
 | `params`           | HTTP    | yes        | none                               | user parameter as routing key                     |
 | `byoe-params`      | HTTP    | yes        | customer, names via params         | parameterized secret names                        |
-| `enrollment_vars`  | HTTP    | yes        | none                               | `enrollment_vars` for per-enrollment URL          |
+| `enrollment_vars`  | HTTP    | yes        | none                               | `{{ enrollment.code }}` for per-enrollment URL    |
 | `recurrent`        | HTTP    | yes        | none                               | `prompt_recurrence` scheduling                    |
 | `routing_vars`     | HTTP    | no         | none                               | post-activation seller knobs via `routing_vars`   |
 | `s3`               | S3      | no         | seller `access_key` / `secret_key` | S3-specific upstream fields                       |
@@ -112,30 +112,26 @@ customer — each enrollment points at a different pair of secrets.
   `ops_testing_parameters` pins them to `ECHO_BYOE_BASE_URL` /
   `ECHO_BYOE_API_KEY` for automated tests.
 
-### `enrollment_vars` — Per-enrollment variables
+### `enrollment_vars` — Per-enrollment code in URLs
 
-Demonstrates `service_options.enrollment_vars`: values rendered once per
-enrollment and reusable in any access interface template. Here the
-enrollment's intrinsic 4-character `code` is captured into an enrollment var
-and embedded in both the user-facing gateway path and the upstream URL, so
-every enrollment gets a unique route.
+Demonstrates per-enrollment routing using the intrinsic `{{ enrollment.code }}`.
+Every enrollment has a unique 4-character `code`, so it can be embedded directly
+in any access interface template — no per-enrollment variable to declare.
 
-- **listing.json** declares
-  `service_options.enrollment_vars.code = "{{ enrollment.code }}"` and uses
-  `{{ enrollment_vars.code }}` inside
-  `user_access_interfaces."HTTP Gateway".base_url`.
-- **offering.json** references the same `{{ enrollment_vars.code }}` inside
-  `upstream_access_config."Echo Service".base_url` so the gateway forwards to
-  the matching upstream path.
+- **listing.json** uses `{{ enrollment.code }}` inside
+  `user_access_interfaces.http_gateway.base_url`.
+- **offering.json** references the same `{{ enrollment.code }}` inside
+  `upstream_access_config.echo_service.base_url`, so the gateway forwards to the
+  matching upstream path.
 
-Rendering runs in two phases: `enrollment_vars` first (so `{{ enrollment.code }}`
-materialises to the enrollment's 4-character code, e.g. `CEFF`), then the
-access interface URL templates consume the rendered value.
+Both templates render to the same code (e.g. `CEFF`) for a given enrollment, so
+every enrollment gets a unique route on both the gateway and upstream sides.
 
-> Every enrollment also has a built-in `code` reachable directly at
-> `/e/<code>` regardless of `base_url` — `{{ enrollment.code }}` exposes that
-> same value. It replaces the old `enrollment_code()` template function (the
-> length argument is gone; the code is always 4 characters).
+> Every enrollment is also reachable directly at `/e/<code>` regardless of
+> `base_url`. The `{{ enrollment.code }}` value replaces both the old
+> `enrollment_code()` template function and the removed
+> `service_options.enrollment_vars` mechanism — reference `{{ enrollment.code }}`
+> directly.
 
 ### `recurrent` — Scheduled execution
 

--- a/data/unitysvc-demo/docs/AUTHORING_GUIDE.md
+++ b/data/unitysvc-demo/docs/AUTHORING_GUIDE.md
@@ -302,7 +302,7 @@ Nothing else is supported. In particular:
 - **Bracket lookup** is *not* supported — `${ customer_secrets[X] }`
   will pass through as a literal string and the test will fail with a
   confusing stderr.
-- **Other Jinja namespaces** (`enrollment_vars.X`, `routing_vars.X`,
+- **Other Jinja namespaces** (`routing_vars.X`, `enrollment.X`,
   arbitrary expressions) inside the secret reference are *not*
   supported yet — use `params` only.
 
@@ -386,7 +386,7 @@ For each new example, before committing:
       `local_testing` scaffold and confirm it works.
 - [ ] Every `${ secrets.X }` / `${ customer_secrets.X }` reference
       uses either a literal name or `{{ params.KEY }}` — nothing
-      else (no bracket lookup, no `enrollment_vars`/`routing_vars`).
+      else (no bracket lookup, no `routing_vars`/`enrollment`).
 - [ ] Every `{{ params.KEY }}` used in a secret reference has a
       matching entry in `service_options.ops_testing_parameters`.
 - [ ] `usvc_seller data validate` passes.

--- a/data/unitysvc-demo/services/enrollment/listing.json
+++ b/data/unitysvc-demo/services/enrollment/listing.json
@@ -1,6 +1,6 @@
 {
   "currency": "USD",
-  "display_name": "Demo HTTP Relay (Enrollment Vars)",
+  "display_name": "Demo HTTP Relay (Enrollment)",
   "documents": {
     "Connectivity test": {
       "$doc_preset": "api_connectivity"
@@ -11,13 +11,14 @@
     "price": "0",
     "type": "constant"
   },
+  "name": "enrollment",
   "schema": "listing_v1",
   "status": "ready",
   "time_created": "2026-04-18T00:00:00Z",
   "user_access_interfaces": {
     "http_gateway": {
       "access_method": "http",
-      "base_url": "${API_GATEWAY_BASE_URL}/demo/echo-enrollment-vars/{{ enrollment.code }}"
+      "base_url": "${API_GATEWAY_BASE_URL}/demo/echo-enrollment/{{ enrollment.code }}"
     }
   }
 }

--- a/data/unitysvc-demo/services/enrollment/listing.override.json
+++ b/data/unitysvc-demo/services/enrollment/listing.override.json
@@ -1,0 +1,3 @@
+{
+  "service_id": "7b44584e-06cd-4551-bbea-b9e2f997ac76"
+}

--- a/data/unitysvc-demo/services/enrollment/offering.json
+++ b/data/unitysvc-demo/services/enrollment/offering.json
@@ -3,7 +3,7 @@
     "http_relay"
   ],
   "description": "Demonstrates per-enrollment URLs. Every enrollment's intrinsic 4-character `{{ enrollment.code }}` is substituted directly into both the customer-facing gateway URL and the upstream URL, giving every enrollment a unique path.",
-  "name": "enrollment_vars",
+  "name": "enrollment",
   "schema": "offering_v1",
   "service_type": "proxy",
   "status": "ready",

--- a/data/unitysvc-demo/services/enrollment_vars/listing.json
+++ b/data/unitysvc-demo/services/enrollment_vars/listing.json
@@ -12,17 +12,12 @@
     "type": "constant"
   },
   "schema": "listing_v1",
-  "service_options": {
-    "enrollment_vars": {
-      "code": "{{ enrollment.code }}"
-    }
-  },
   "status": "ready",
   "time_created": "2026-04-18T00:00:00Z",
   "user_access_interfaces": {
     "http_gateway": {
       "access_method": "http",
-      "base_url": "${API_GATEWAY_BASE_URL}/demo/echo-enrollment-vars/{{ enrollment_vars.code }}"
+      "base_url": "${API_GATEWAY_BASE_URL}/demo/echo-enrollment-vars/{{ enrollment.code }}"
     }
   }
 }

--- a/data/unitysvc-demo/services/enrollment_vars/listing.json
+++ b/data/unitysvc-demo/services/enrollment_vars/listing.json
@@ -14,7 +14,7 @@
   "schema": "listing_v1",
   "service_options": {
     "enrollment_vars": {
-      "code": "{{ enrollment_code(6) }}"
+      "code": "{{ enrollment.code }}"
     }
   },
   "status": "ready",

--- a/data/unitysvc-demo/services/enrollment_vars/listing.override.json
+++ b/data/unitysvc-demo/services/enrollment_vars/listing.override.json
@@ -1,4 +1,0 @@
-{
-  "name": "enrollment_vars",
-  "service_id": "57a96895-c038-498b-b2e0-877b07b2604e"
-}

--- a/data/unitysvc-demo/services/enrollment_vars/offering.json
+++ b/data/unitysvc-demo/services/enrollment_vars/offering.json
@@ -2,7 +2,7 @@
   "capabilities": [
     "http_relay"
   ],
-  "description": "Demonstrates per-enrollment variables. A short code is generated once per enrollment via `{{ enrollment_code(6) }}` and substituted into both the customer-facing gateway URL and the upstream URL, giving every enrollment a unique path.",
+  "description": "Demonstrates per-enrollment variables. Every enrollment's intrinsic 4-character `{{ enrollment.code }}` is captured into an enrollment var and substituted into both the customer-facing gateway URL and the upstream URL, giving every enrollment a unique path.",
   "name": "enrollment_vars",
   "schema": "offering_v1",
   "service_type": "proxy",

--- a/data/unitysvc-demo/services/enrollment_vars/offering.json
+++ b/data/unitysvc-demo/services/enrollment_vars/offering.json
@@ -2,7 +2,7 @@
   "capabilities": [
     "http_relay"
   ],
-  "description": "Demonstrates per-enrollment variables. Every enrollment's intrinsic 4-character `{{ enrollment.code }}` is captured into an enrollment var and substituted into both the customer-facing gateway URL and the upstream URL, giving every enrollment a unique path.",
+  "description": "Demonstrates per-enrollment URLs. Every enrollment's intrinsic 4-character `{{ enrollment.code }}` is substituted directly into both the customer-facing gateway URL and the upstream URL, giving every enrollment a unique path.",
   "name": "enrollment_vars",
   "schema": "offering_v1",
   "service_type": "proxy",
@@ -14,7 +14,7 @@
   "upstream_access_config": {
     "echo_service": {
       "access_method": "http",
-      "base_url": "https://echo.unitysvc.dev/{{ enrollment_vars.code }}"
+      "base_url": "https://echo.unitysvc.dev/{{ enrollment.code }}"
     }
   }
 }


### PR DESCRIPTION
## Summary

Migrates the `enrollment_vars` demo service to the intrinsic `{{ enrollment.code }}`, completing the removal of the `enrollment_vars` mechanism (platform: unitysvc#1206, unitysvc-core v0.1.18).

- **listing.json** — dropped the `service_options.enrollment_vars` block; `user_access_interfaces.http_gateway.base_url` now uses `{{ enrollment.code }}` directly.
- **offering.json** — `upstream_access_config.echo_service.base_url` uses `{{ enrollment.code }}`; description updated.
- **README.md / AUTHORING_GUIDE.md** — documentation updated to reflect direct `{{ enrollment.code }}` usage (no per-enrollment variable to declare).

The intrinsic code is substituted directly into both the gateway and upstream URLs, giving each enrollment a unique route — and the same enrollment is reachable at `/e/<code>`.

## Verification
- `usvc_seller data validate` ✅ (against `unitysvc-core 0.1.18` — confirms `{{ enrollment.code }}` validates directly in `user_access_interfaces` / `upstream_access_config`)
- `usvc_seller data format --check` ✅ 0 files need formatting

> Requires `unitysvc-core >= 0.1.18` for seller-side validation (the `enrollment` namespace). Earlier releases reject `{{ enrollment.code }}` used directly in interface templates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)