### PR TITLE
ci: point the staging upload at unitysvc/.github so secrets inherit

### DIFF
--- a/.github/workflows/upload-data.yml
+++ b/.github/workflows/upload-data.yml
@@ -1,13 +1,21 @@
 name: Upload Data
 
+# The reusable workflow MUST live in the same org as this repo. GitHub only
+# honours `secrets: inherit` within one organization/enterprise — while this
+# repo (now under `unitysvc`) called `unitysvc-labs/.github`, the job received
+# nothing but `github_token` and every upload died on "Missing seller API key".
+# The secret-free callers (format-check, validate-data) still point at
+# unitysvc-labs/.github because unitysvc/.github does not carry those yet.
+
 on:
   pull_request:
     types: [closed]
     branches: [main]
+  workflow_dispatch:
 
 jobs:
   upload:
-    uses: unitysvc-labs/.github/.github/workflows/seller-upload-staging.yml@main
+    uses: unitysvc/.github/.github/workflows/seller-upload-staging.yml@main
     secrets: inherit
     permissions:
       contents: write


### PR DESCRIPTION
## Problem

Every `Upload Data` run since 2026-05-31 has failed at the **Seed seller-secrets store** step with:

```
✗ Missing seller API key. Set $UNITYSVC_SELLER_API_KEY or pass --api-key.
```

([latest run](https://github.com/unitysvc/unitysvc-services-demo/actions/runs/31398903969/job/93488642842))

## Root cause

This repo moved to the **`unitysvc`** org, but the caller still referenced **`unitysvc-labs/.github`**. GitHub only honours `secrets: inherit` for reusable workflows in the **same organization/enterprise** — cross-org, it silently passes nothing.

The failing job's own env dump proves it:

```
UNITYSVC_SELLER_API_KEY:
UNITYSVC_SELLER_API_URL:
ALL_SECRETS_JSON: { "github_token": "***" }
ALL_VARS_JSON: {}
```

Not even this repo's own `S3_ACCESS_KEY` / `S3_SECRET_KEY` (created 14 minutes before that run) came through — only the auto-provisioned `github_token`.

Corroborating evidence:

- Sibling repos (`unitysvc-services-http`, `-notify`, `-cohere`) are still in `unitysvc-labs`, call the *same* reusable workflow, and their uploads succeed.
- In this repo the cross-org callers that need **no** secrets — Format Check, Validate Data — pass fine. Only the secret-consuming one fails.
- Last successful `Upload Data` here was 2026-05-03, i.e. before the org move.

## Change

Repoint the upload caller at the same-org copy:

```diff
-    uses: unitysvc-labs/.github/.github/workflows/seller-upload-staging.yml@main
+    uses: unitysvc/.github/.github/workflows/seller-upload-staging.yml@main
```

Plus `workflow_dispatch`, so the upload can be exercised without merging a PR (matching the sibling repos' callers).

`format-check.yml` and `validate-data.yml` intentionally stay on `unitysvc-labs/.github` — they need no secrets, they pass today, and `unitysvc/.github` does not carry those reusable workflows. Same for `populate-services.yml`; this repo has no populator config.

## Still required before a run goes green

1. Add `UNITYSVC_SELLER_STAGING_API_KEY` and `UNITYSVC_SELLER_STAGING_API_URL` (`https://seller.staging.unitysvc.com/v1/`) as secrets on this repo, or at the `unitysvc` org with this repo granted access. Neither exists today.
2. Note that `unitysvc/.github`'s copy of `seller-upload-staging.yml` is a **stale fork** of the labs one: it predates unitysvc#1709, has no `.env.example` branch, and pins `unitysvc-sellers>=0.2.0` instead of `>=0.2.20`. So `seller.secrets.txt` is ignored and seeding falls back to grepping names out of `specs/`. For that path these must also exist as GitHub secrets/variables:

   `ECHO_API_KEY`, `ECHO_BYOE_API_KEY`, `ECHO_BYOE_BASE_URL`, `HTTP_RELAY_BASE_URL`, `SMTP_HOST`, `SMTP_RELAY_HOST`, `SMTP_RELAY_PASSWORD`, `SMTP_RELAY_PORT`, `SMTP_RELAY_USERNAME`

   A missing name there is `::warning::`-skipped rather than failed. Syncing the labs version of the reusable workflow into `unitysvc/.github` would collapse all nine back down to the committed manifest and is the better long-term fix.

## Caveat

Org secret lists were not readable from here (HTTP 403, not an org admin), so "the secrets aren't reaching this repo" is inferred from the job's `toJSON(secrets)` dump rather than read from org settings. If `UNITYSVC_SELLER_STAGING_API_KEY` turns out to already exist at the `unitysvc` org level, check that org secret's repository-access setting instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)